### PR TITLE
Add support for Apple Crash Reporter (with tests)

### DIFF
--- a/FTB/Signatures/apple-crash-report-example.txt
+++ b/FTB/Signatures/apple-crash-report-example.txt
@@ -1,0 +1,59 @@
+Process:               js-dbg-64-dm-darwin-a523d4c7efe2 [27938]
+Path:                  /Users/USER/*/js-dbg-64-dm-darwin-a523d4c7efe2
+Identifier:            js-dbg-64-dm-darwin-a523d4c7efe2
+Version:               ???
+Code Type:             X86-64 (Native)
+Parent Process:        bash [27933]
+Responsible:           iTerm2 [91188]
+User ID:               501
+
+Date/Time:             2015-11-19 17:01:28.214 -0800
+OS Version:            Mac OS X 10.11.1 (15B42)
+Report Version:        11
+Anonymous UUID:        2D34C956-9487-7B72-EFCB-E61B989F1869
+
+
+Time Awake Since Boot: 25000 seconds
+
+System Integrity Protection: enabled
+
+Crashed Thread:        0  Dispatch queue: com.apple.main-thread
+
+Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
+Exception Codes:       KERN_PROTECTION_FAILURE at 0x00007fff5f3fff98
+
+VM Regions Near 0x7fff5f3fff98:
+    Stack                  00007000034c5000-0000700003547000 [  520K] rw-/rwx SM=COW  thread 59
+--> STACK GUARD            00007fff5bc00000-00007fff5f400000 [ 56.0M] ---/rwx SM=NUL  stack guard for thread 0
+    Stack                  00007fff5f400000-00007fff5fc00000 [ 8192K] rw-/rwx SM=PRV  thread 0
+
+Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
+0   js-dbg-64-dm-darwin-a523d4c7efe2    0x00000001004b04c4 js::jit::MacroAssembler::Pop(js::jit::Register) + 180 (MacroAssembler-inl.h:50)
+1   js-dbg-64-dm-darwin-a523d4c7efe2    0x0000000100395e01 js::jit::ICGetPropCallNativeCompiler::generateStubCode(js::jit::MacroAssembler&) + 1329 (SharedIC.cpp:3701)
+2   js-dbg-64-dm-darwin-a523d4c7efe2    0x0000000100385112 js::jit::ICStubCompiler::getStubCode() + 242 (SharedIC.cpp:734)
+3   js-dbg-64-dm-darwin-a523d4c7efe2    0x00000001003961e5 js::jit::ICGetPropCallNativeCompiler::getStub(js::jit::ICStubSpace*) + 245 (SharedIC.cpp:3721)
+4   js-dbg-64-dm-darwin-a523d4c7efe2    0x000000010038fe57 js::jit::DoGetPropFallback(JSContext*, js::jit::BaselineFrame*, js::jit::ICGetProp_Fallback*, JS::MutableHandle<JS::Value>, JS::MutableHandle<JS::Value>) + 7687 (SharedIC.h:2872)
+5   ???                             0x0000000101e48547 0 + 4326720839
+6   libsystem_c.dylib               0x00007fff841e10ff __cxa_finalize_ranges + 345
+7   XUL                             0x0000000102cff002 0x101c38000 + 17592322
+8   com.apple.AppKit                0x00007fff957c91c5 -[NSApplication _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 454
+
+Thread 1:
+0   libsystem_kernel.dylib          0x00007fff9700fc96 mach_msg_trap + 10
+1   libsystem_kernel.dylib          0x00007fff9700f0d7 mach_msg + 55
+2   js-dbg-64-dm-darwin-a523d4c7efe2    0x00000001000e0ebf AsmJSMachExceptionHandlerThread(void*) + 415 (AsmJSSignalHandlers.cpp:950)
+3   js-dbg-64-dm-darwin-a523d4c7efe2    0x0000000100720c3f nspr::Thread::ThreadRoutine(void*) + 31 (Utility.h:369)
+4   libsystem_pthread.dylib         0x00007fff96ef29b1 _pthread_body + 131
+5   libsystem_pthread.dylib         0x00007fff96ef292e _pthread_start + 168
+6   libsystem_pthread.dylib         0x00007fff96ef0385 thread_start + 13
+
+Thread 0 crashed with X86 Thread State (64-bit):
+  rax: 0x0000000000000000  rbx: 0x00007fff7bb75bd0  rcx: 0x0000010000000203  rdx: 0x0000020000000200
+  rdi: 0x00007fff7bb751e8  rsi: 0x0000000000012068  rbp: 0x00007fff5fbf95b0  rsp: 0x00007fff5fbf95a0
+   r8: 0x0000000000000040   r9: 0x00007fff7bb751e0  r10: 0xffffffffffffffff  r11: 0x00007fff8c7a7201
+  r12: 0x00000000001e374a  r13: 0x00007fff5fbf9680  r14: 0x00007fff5fbfa228  r15: 0x0000000000000002
+  rip: 0x00000001004b04c4  rfl: 0x0000000000010206  cr2: 0x0000000000000000
+  
+Logical CPU:     0
+Error Code:      0x00000006
+Trap Number:     14

--- a/FTB/Signatures/tests.py
+++ b/FTB/Signatures/tests.py
@@ -13,7 +13,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 '''
 import unittest
 from FTB.Signatures.CrashInfo import ASanCrashInfo, GDBCrashInfo, CrashInfo,\
-    NoCrashInfo, MinidumpCrashInfo
+    NoCrashInfo, MinidumpCrashInfo, AppleCrashInfo
 from FTB.Signatures.CrashSignature import CrashSignature
 from FTB.Signatures import RegisterHelper
 
@@ -647,6 +647,36 @@ class MinidumpSelectorTest(unittest.TestCase):
         
         crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
         self.assertEqual(crashInfo.crashAddress, long(0x3e800006acb))
+
+class AppleParserTestCrash(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86-64", "macosx")
+
+        with open('apple-crash-report-example.txt', 'r') as f:
+            crashInfo = AppleCrashInfo([], [], config, f.read().splitlines())
+
+        self.assertEqual(len(crashInfo.backtrace), 9)
+        self.assertEqual(crashInfo.backtrace[0], "js::jit::MacroAssembler::Pop")
+        self.assertEqual(crashInfo.backtrace[1], "js::jit::ICGetPropCallNativeCompiler::generateStubCode")
+        self.assertEqual(crashInfo.backtrace[2], "js::jit::ICStubCompiler::getStubCode")
+        self.assertEqual(crashInfo.backtrace[3], "js::jit::ICGetPropCallNativeCompiler::getStub")
+        self.assertEqual(crashInfo.backtrace[4], "js::jit::DoGetPropFallback")
+        self.assertEqual(crashInfo.backtrace[5], "??")
+        self.assertEqual(crashInfo.backtrace[6], "__cxa_finalize_ranges")
+        self.assertEqual(crashInfo.backtrace[7], "??")
+        self.assertEqual(crashInfo.backtrace[8], "-[NSApplication _nextEventMatchingEventMask:untilDate:inMode:dequeue:]")
+
+        self.assertEqual(crashInfo.crashAddress, long(0x00007fff5f3fff98))
+
+class AppleSelectorTest(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86-64", "macosx")
+
+        with open('apple-crash-report-example.txt', 'r') as f:
+            crashData = f.read().splitlines()
+
+        crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
+        self.assertEqual(crashInfo.crashAddress, long(0x00007fff5f3fff98))
 
 class UBSanParserTestCrash(unittest.TestCase):
     def runTest(self):


### PR DESCRIPTION
Replaces #144. Includes tests and strips stack entries down to the function name.