### PR TITLE
Add support for cdb.exe (Windows command-line debugger) with tests.

### DIFF
--- a/FTB/Signatures/CrashInfo.py
+++ b/FTB/Signatures/CrashInfo.py
@@ -1039,7 +1039,7 @@ class CDBCrashInfo(CrashInfo):
                 #     Minor       : Unknown
                 components = line.split(None, 4)
                 stackEntry = components[2]
-                if components[0] == "Instruction":
+                if components[0] in ["Excluded", "Instruction"]:
                     inCrashingThread = False
                     continue
                 if stackEntry.endswith("Unknown"):

--- a/FTB/Signatures/CrashInfo.py
+++ b/FTB/Signatures/CrashInfo.py
@@ -1019,9 +1019,9 @@ class CDBCrashInfo(CrashInfo):
         inCrashingThread = False
         for line in crashData:
             # Crash address
-            if line.startswith("Instruction Address:"):
+            if line.startswith("Exception Faulting Address:"):
                 # Example:
-                #     Instruction Address: 0x000007fef86c13e4
+                #     Exception Faulting Address: 0x7fef86c13e4
                 address = line.split(": ")[1]
                 self.crashAddress = long(address, 16)
 

--- a/FTB/Signatures/CrashInfo.py
+++ b/FTB/Signatures/CrashInfo.py
@@ -1065,6 +1065,13 @@ class CDBCrashInfo(CrashInfo):
                 address = line.split(": ")[1]
                 self.crashAddress = long(address, 16)
 
+            # Crash instruction
+            if line.startswith("Faulting Instruction:"):
+                # Example:
+                #     Faulting Instruction:01206fbd int 3
+                cInstruction = line.split(":")[1].split(None, 1)[1]
+                self.crashInstruction = cInstruction
+
             # Start of stack for crashing thread
             if re.match(r'\sHash Usage : Stack Trace:', line):
                 inCrashingThread = True

--- a/FTB/Signatures/cdb-crash-report-example-1.txt
+++ b/FTB/Signatures/cdb-crash-report-example-1.txt
@@ -116,5 +116,366 @@ Exploitability Classification: UNKNOWN
 Recommended Bug Title: Possible Stack Corruption starting at mozglue!moz_abort+0x0000000000000004 (Hash=0xc3eefb5e.0x784ac7be)
 
 The stack trace contains one or more locations for which no symbol or module could be found. This may be a sign of stack corruption.
+0:000> ~*kPn 250
+
+.  0  Id: 9d0.12c4 Suspend: 0 Teb: 000007ff`fffdd000 Unfrozen
+ # Child-SP          RetAddr           Call Site
+00 00000000`0033bb10 000007fe`f86c45cd mozglue!moz_abort(void)+0x4 [c:\users\mozillaadmin\trees\mozilla-central\memory\build\jemalloc_config.cpp @ 159]
+01 00000000`0033bb40 000007fe`f86c3de3 mozglue!arena_run_split(
+			struct arena_s * arena = 0x00000000`08c00000,
+			struct arena_run_s * run = 0x00000000`08c52000,
+			unsigned int64 size = 0x8000,
+			int large = 0n1,
+			int zero = 0n0)+0x27d [c:\users\mozillaadmin\trees\mozilla-central\memory\mozjemalloc\jemalloc.c @ 3481]
+02 00000000`0033bbd0 000007fe`f86c2f79 mozglue!arena_run_alloc(
+			struct arena_s * arena = 0x00000000`00008000,
+			struct arena_bin_s * bin = 0x00000000`00000000,
+			unsigned int64 size = 0x8000,
+			int large = 0n134987776,
+			int zero = 0n0)+0x103 [c:\users\mozillaadmin\trees\mozilla-central\memory\mozjemalloc\jemalloc.c @ 3651]
+03 00000000`0033bc40 000007fe`f86c39bd mozglue!arena_malloc_large(
+			struct arena_s * arena = 0x00000000`00004000,
+			unsigned int64 size = 0x8b,
+			int zero = 0n134987776)+0x49 [c:\users\mozillaadmin\trees\mozilla-central\memory\mozjemalloc\jemalloc.c @ 4254]
+04 00000000`0033bc80 000007fe`f86c75fd mozglue!arena_ralloc(
+			void * ptr = 0x00000000`0000008b,
+			unsigned int64 size = 0x8000,
+			unsigned int64 oldsize = 0x18)+0x25d [c:\users\mozillaadmin\trees\mozilla-central\memory\mozjemalloc\jemalloc.c @ 4891]
+05 00000000`0033bcb0 00000001`3fb93053 mozglue!je_realloc(
+			void * ptr = 0x00000000`00008000,
+			unsigned int64 size = 0x1`3ff377f7)+0x3d [c:\users\mozillaadmin\trees\mozilla-central\memory\mozjemalloc\jemalloc.c @ 6404]
+06 00000000`0033bce0 00000001`3fb99695 js_64_prof_windows_a523d4c7efe2!mozilla::VectorBase<unsigned char,256,js::SystemAllocPolicy,mozilla::Vector<unsigned char,256,js::SystemAllocPolicy> >::growStorageBy(
+			unsigned int64 aIncr = 0x1`3fdd12ba)+0x53 [c:\users\mozillaadmin\shell-cache\js-64-prof-windows-a523d4c7efe2\objdir-js\dist\include\mozilla\vector.h @ 885]
+07 00000000`0033bd10 00000001`3fb98d1d js_64_prof_windows_a523d4c7efe2!js::jit::X86Encoding::BaseAssembler::X86InstructionFormatter::oneByteOp64(
+			js::jit::X86Encoding::OneByteOpcodeID opcode = 0n24 (No matching enumerant),
+			int offset = 0n1,
+			js::jit::X86Encoding::RegisterID base = 0n24 (No matching enumerant),
+			int reg = 0n0)+0x35 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\x86-shared\baseassembler-x86-shared.h @ 4341]
+08 00000000`0033bd40 00000001`3ff3d872 js_64_prof_windows_a523d4c7efe2!js::jit::X86Encoding::BaseAssemblerX64::movq_mr(
+			int offset = 0n134643712,
+			js::jit::X86Encoding::RegisterID base = 0n111517848 (No matching enumerant),
+			js::jit::X86Encoding::RegisterID dst = 0n1073032122 (No matching enumerant))+0x7d [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\x64\baseassembler-x64.h @ 469]
+09 00000000`0033bd80 00000001`3ff4684c js_64_prof_windows_a523d4c7efe2!js::jit::MacroAssemblerX64::load64(
+			struct js::jit::Address * address = 0x00000008`00000002,
+			struct js::jit::Register64 dest = struct js::jit::Register64)+0xd2 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\x64\macroassembler-x64.h @ 774]
+0a 00000000`0033bdc0 00000001`3ff38968 js_64_prof_windows_a523d4c7efe2!js::jit::CodeGenerator::visitElements(
+			class js::jit::LElements * lir = 0xfffffff4`08070021)+0x4c [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\codegenerator.cpp @ 2579]
+0b 00000000`0033bdf0 00000001`3ff381a2 js_64_prof_windows_a523d4c7efe2!js::jit::CodeGenerator::generateBody(void)+0x258 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\codegenerator.cpp @ 4173]
+0c 00000000`0033bea0 00000001`3fe88759 js_64_prof_windows_a523d4c7efe2!js::jit::CodeGenerator::generate(void)+0x162 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\codegenerator.cpp @ 7893]
+0d 00000000`0033bed0 00000001`3fe8cc46 js_64_prof_windows_a523d4c7efe2!js::jit::GenerateCode(
+			class js::jit::MIRGenerator * mir = 0x00000000`00000001,
+			class js::jit::LIRGraph * lir = 0x00000000`00000000)+0xd9 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\ion.cpp @ 1961]
+0e 00000000`0033bf20 00000001`3fe83398 js_64_prof_windows_a523d4c7efe2!js::jit::IonCompile(
+			struct JSContext * cx = 0x00000000`080009c0,
+			class JSScript * script = 0x00000000`08000000,
+			class js::jit::BaselineFrame * baselineFrame = 0x00000000`08000000,
+			unsigned char * osrPc = 0x000007fe`f86c2bfc "H???",
+			bool constructing = false,
+			bool recompile = false,
+			js::jit::OptimizationLevel optimizationLevel = Optimization_Normal (0n1))+0xb86 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\ion.cpp @ 2249]
+0f 00000000`0033c270 00000001`3fe8351a js_64_prof_windows_a523d4c7efe2!js::jit::Compile(
+			struct JSContext * cx = 0x00000000`00720400,
+			class JS::Handle<JSScript *> script = class JS::Handle<JSScript *>,
+			class js::jit::BaselineFrame * osrFrame = 0x00000000`007d1c20,
+			unsigned char * osrPc = 0x00000000`0033c480 "",
+			bool constructing = false,
+			bool forceRecompile = false)+0x1a8 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\ion.cpp @ 2419]
+10 00000000`0033c330 00000001`3ffa43d5 js_64_prof_windows_a523d4c7efe2!js::jit::CompileFunctionForBaseline(
+			struct JSContext * cx = 0x00000000`05d78800,
+			class JS::Handle<JSScript *> script = class JS::Handle<JSScript *>,
+			class js::jit::BaselineFrame * frame = 0xfffa0000`00000000)+0x9a [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\ion.cpp @ 2612]
+11 00000000`0033c370 00000001`3ffa404b js_64_prof_windows_a523d4c7efe2!js::jit::EnsureCanEnterIon(
+			struct JSContext * cx = 0x00000000`0033c5c8,
+			class js::jit::ICWarmUpCounter_Fallback * stub = 0x00000001`3ff7d528,
+			class js::jit::BaselineFrame * frame = 0x00000000`00720400,
+			class JS::Handle<JSScript *> script = class JS::Handle<JSScript *>,
+			unsigned char * pc = 0x00000000`05d788c9 "--- memory read error at address 0x00000000`05d788c9 ---",
+			void ** jitcodePtr = 0x00000000`0033c410)+0x45 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\baselineic.cpp @ 69]
+12 00000000`0033c3a0 00000109`f77b2630 js_64_prof_windows_a523d4c7efe2!js::jit::DoWarmUpCounterFallback(
+			struct JSContext * cx = 0x00000000`00000000,
+			class js::jit::BaselineFrame * frame = 0x00000000`0033c4a8,
+			class js::jit::ICWarmUpCounter_Fallback * stub = 0x00000000`0033c488,
+			struct js::jit::IonOsrTempData ** infoPtr = 0x00000000`00000000)+0xeb [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\baselineic.cpp @ 230]
+13 00000000`0033c410 00000000`00000000 0x109`f77b2630
+
+   1  Id: 9d0.1008 Suspend: 1 Teb: 000007ff`fffdb000 Unfrozen
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for KERNELBASE.dll -
+ # Child-SP          RetAddr           Call Site
+00 00000000`0295f968 000007fe`fd2010dc ntdll!ZwWaitForSingleObject+0xa
+*** WARNING: Unable to verify checksum for nspr4.dll
+01 00000000`0295f970 000007fe`f869d2e8 KERNELBASE!WaitForSingleObjectEx+0x9c
+02 00000000`0295fa10 000007fe`f8699296 nspr4!_PR_MD_WAIT_CV(
+			struct _MDCVar * cv = 0x00000000`0042b530,
+			struct _MDLock * lock = 0x00000000`00000002,
+			unsigned int timeout = 0x72f000)+0xa8 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95cv.c @ 250]
+03 00000000`0295fa40 00000001`3fdaa646 nspr4!_PR_WaitCondVar(
+			struct PRThread * thread = 0x00000000`00706180,
+			struct PRCondVar * cvar = 0x00000000`0072f000,
+			struct PRLock * lock = 0x00000000`0041bcb0,
+			unsigned int timeout = 0x42b870)+0x66 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\prucv.c @ 173]
+04 00000000`0295fa70 000007fe`f869abd0 js_64_prof_windows_a523d4c7efe2!js::HelperThread::threadLoop(void)+0x246 [c:\users\mozillaadmin\trees\mozilla-central\js\src\vm\helperthreads.cpp @ 1596]
+05 00000000`0295faa0 000007fe`f869c17a nspr4!_PR_NativeRunThread(
+			void * arg = 0x00000000`004164d0)+0x100 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\pruthr.c @ 419]
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for msvcr120.dll -
+06 00000000`0295fad0 000007fe`f8744f7f nspr4!pr_root(
+			void * arg = 0x00000000`0042b870)+0xa [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95thred.c @ 91]
+07 00000000`0295fb00 000007fe`f8745126 msvcr120!beginthreadex+0x107
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for kernel32.dll -
+08 00000000`0295fb30 00000000`773359dd msvcr120!endthreadex+0x192
+09 00000000`0295fb60 00000000`7746a631 kernel32!BaseThreadInitThunk+0xd
+0a 00000000`0295fb90 00000000`00000000 ntdll!RtlUserThreadStart+0x21
+
+   2  Id: 9d0.13dc Suspend: 1 Teb: 000007ff`fffd9000 Unfrozen
+ # Child-SP          RetAddr           Call Site
+00 00000000`02d0fb78 000007fe`fd2010dc ntdll!ZwWaitForSingleObject+0xa
+01 00000000`02d0fb80 000007fe`f869d2e8 KERNELBASE!WaitForSingleObjectEx+0x9c
+02 00000000`02d0fc20 000007fe`f8699296 nspr4!_PR_MD_WAIT_CV(
+			struct _MDCVar * cv = 0x00000000`0042bcf0,
+			struct _MDLock * lock = 0x00000000`00000002,
+			unsigned int timeout = 0x72f1f8)+0xa8 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95cv.c @ 250]
+03 00000000`02d0fc50 00000001`3fdaa646 nspr4!_PR_WaitCondVar(
+			struct PRThread * thread = 0x00000000`00706180,
+			struct PRCondVar * cvar = 0x00000000`0072f1f8,
+			struct PRLock * lock = 0x00000000`0041bcb0,
+			unsigned int timeout = 0x42c090)+0x66 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\prucv.c @ 173]
+04 00000000`02d0fc80 000007fe`f869abd0 js_64_prof_windows_a523d4c7efe2!js::HelperThread::threadLoop(void)+0x246 [c:\users\mozillaadmin\trees\mozilla-central\js\src\vm\helperthreads.cpp @ 1596]
+05 00000000`02d0fcb0 000007fe`f869c17a nspr4!_PR_NativeRunThread(
+			void * arg = 0x00000000`0042bf20)+0x100 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\pruthr.c @ 419]
+06 00000000`02d0fce0 000007fe`f8744f7f nspr4!pr_root(
+			void * arg = 0x00000000`0042c090)+0xa [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95thred.c @ 91]
+07 00000000`02d0fd10 000007fe`f8745126 msvcr120!beginthreadex+0x107
+08 00000000`02d0fd40 00000000`773359dd msvcr120!endthreadex+0x192
+09 00000000`02d0fd70 00000000`7746a631 kernel32!BaseThreadInitThunk+0xd
+0a 00000000`02d0fda0 00000000`00000000 ntdll!RtlUserThreadStart+0x21
+
+   3  Id: 9d0.5b0 Suspend: 1 Teb: 000007ff`fffd7000 Unfrozen
+ # Child-SP          RetAddr           Call Site
+00 00000000`0308fce8 000007fe`fd2010dc ntdll!ZwWaitForSingleObject+0xa
+01 00000000`0308fcf0 000007fe`f869d2e8 KERNELBASE!WaitForSingleObjectEx+0x9c
+02 00000000`0308fd90 000007fe`f8699296 nspr4!_PR_MD_WAIT_CV(
+			struct _MDCVar * cv = 0x00000000`0042b870,
+			struct _MDLock * lock = 0x00000000`00000002,
+			unsigned int timeout = 0x72f3f0)+0xa8 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95cv.c @ 250]
+03 00000000`0308fdc0 00000001`3fdaa646 nspr4!_PR_WaitCondVar(
+			struct PRThread * thread = 0x00000000`00706180,
+			struct PRCondVar * cvar = 0x00000000`0072f3f0,
+			struct PRLock * lock = 0x00000000`0041bcb0,
+			unsigned int timeout = 0x42cec0)+0x66 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\prucv.c @ 173]
+04 00000000`0308fdf0 000007fe`f869abd0 js_64_prof_windows_a523d4c7efe2!js::HelperThread::threadLoop(void)+0x246 [c:\users\mozillaadmin\trees\mozilla-central\js\src\vm\helperthreads.cpp @ 1596]
+05 00000000`0308fe20 000007fe`f869c17a nspr4!_PR_NativeRunThread(
+			void * arg = 0x00000000`0041d370)+0x100 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\pruthr.c @ 419]
+06 00000000`0308fe50 000007fe`f8744f7f nspr4!pr_root(
+			void * arg = 0x00000000`0042cec0)+0xa [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95thred.c @ 91]
+07 00000000`0308fe80 000007fe`f8745126 msvcr120!beginthreadex+0x107
+08 00000000`0308feb0 00000000`773359dd msvcr120!endthreadex+0x192
+09 00000000`0308fee0 00000000`7746a631 kernel32!BaseThreadInitThunk+0xd
+0a 00000000`0308ff10 00000000`00000000 ntdll!RtlUserThreadStart+0x21
+
+   4  Id: 9d0.1298 Suspend: 1 Teb: 000007ff`fffd5000 Unfrozen
+ # Child-SP          RetAddr           Call Site
+00 00000000`032ef718 000007fe`fd2010dc ntdll!ZwWaitForSingleObject+0xa
+01 00000000`032ef720 000007fe`f869d2e8 KERNELBASE!WaitForSingleObjectEx+0x9c
+02 00000000`032ef7c0 000007fe`f8699296 nspr4!_PR_MD_WAIT_CV(
+			struct _MDCVar * cv = 0x00000000`0042baa0,
+			struct _MDLock * lock = 0x00000000`00000002,
+			unsigned int timeout = 0x72f5e8)+0xa8 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95cv.c @ 250]
+03 00000000`032ef7f0 00000001`3fdaa646 nspr4!_PR_WaitCondVar(
+			struct PRThread * thread = 0x00000000`00706180,
+			struct PRCondVar * cvar = 0x00000000`0072f5e8,
+			struct PRLock * lock = 0x00000000`0041bcb0,
+			unsigned int timeout = 0x42c090)+0x66 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\prucv.c @ 173]
+04 00000000`032ef820 000007fe`f869abd0 js_64_prof_windows_a523d4c7efe2!js::HelperThread::threadLoop(void)+0x246 [c:\users\mozillaadmin\trees\mozilla-central\js\src\vm\helperthreads.cpp @ 1596]
+05 00000000`032ef850 000007fe`f869c17a nspr4!_PR_NativeRunThread(
+			void * arg = 0x00000000`0041d3d0)+0x100 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\pruthr.c @ 419]
+06 00000000`032ef880 000007fe`f8744f7f nspr4!pr_root(
+			void * arg = 0x00000000`0042c090)+0xa [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95thred.c @ 91]
+07 00000000`032ef8b0 000007fe`f8745126 msvcr120!beginthreadex+0x107
+08 00000000`032ef8e0 00000000`773359dd msvcr120!endthreadex+0x192
+09 00000000`032ef910 00000000`7746a631 kernel32!BaseThreadInitThunk+0xd
+0a 00000000`032ef940 00000000`00000000 ntdll!RtlUserThreadStart+0x21
+
+   5  Id: 9d0.8dc Suspend: 1 Teb: 000007ff`fffd3000 Unfrozen
+ # Child-SP          RetAddr           Call Site
+00 00000000`0355f6b8 000007fe`fd2010dc ntdll!ZwWaitForSingleObject+0xa
+01 00000000`0355f6c0 000007fe`f869d2e8 KERNELBASE!WaitForSingleObjectEx+0x9c
+02 00000000`0355f760 000007fe`f8699296 nspr4!_PR_MD_WAIT_CV(
+			struct _MDCVar * cv = 0x00000000`0042dcf0,
+			struct _MDLock * lock = 0x00000000`00000002,
+			unsigned int timeout = 0x72f7e0)+0xa8 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95cv.c @ 250]
+03 00000000`0355f790 00000001`3fdaa646 nspr4!_PR_WaitCondVar(
+			struct PRThread * thread = 0x00000000`00706180,
+			struct PRCondVar * cvar = 0x00000000`0072f7e0,
+			struct PRLock * lock = 0x00000000`0041bcb0,
+			unsigned int timeout = 0x42e090)+0x66 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\prucv.c @ 173]
+04 00000000`0355f7c0 000007fe`f869abd0 js_64_prof_windows_a523d4c7efe2!js::HelperThread::threadLoop(void)+0x246 [c:\users\mozillaadmin\trees\mozilla-central\js\src\vm\helperthreads.cpp @ 1596]
+05 00000000`0355f7f0 000007fe`f869c17a nspr4!_PR_NativeRunThread(
+			void * arg = 0x00000000`0042df20)+0x100 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\pruthr.c @ 419]
+06 00000000`0355f820 000007fe`f8744f7f nspr4!pr_root(
+			void * arg = 0x00000000`0042e090)+0xa [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95thred.c @ 91]
+07 00000000`0355f850 000007fe`f8745126 msvcr120!beginthreadex+0x107
+08 00000000`0355f880 00000000`773359dd msvcr120!endthreadex+0x192
+09 00000000`0355f8b0 00000000`7746a631 kernel32!BaseThreadInitThunk+0xd
+0a 00000000`0355f8e0 00000000`00000000 ntdll!RtlUserThreadStart+0x21
+
+   6  Id: 9d0.e4c Suspend: 1 Teb: 000007ff`fffae000 Unfrozen
+ # Child-SP          RetAddr           Call Site
+00 00000000`038ef848 000007fe`fd2010dc ntdll!ZwWaitForSingleObject+0xa
+01 00000000`038ef850 000007fe`f869d2e8 KERNELBASE!WaitForSingleObjectEx+0x9c
+02 00000000`038ef8f0 000007fe`f8699296 nspr4!_PR_MD_WAIT_CV(
+			struct _MDCVar * cv = 0x00000000`0042e510,
+			struct _MDLock * lock = 0x00000000`00000002,
+			unsigned int timeout = 0x72f9d8)+0xa8 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95cv.c @ 250]
+03 00000000`038ef920 00000001`3fdaa646 nspr4!_PR_WaitCondVar(
+			struct PRThread * thread = 0x00000000`00706180,
+			struct PRCondVar * cvar = 0x00000000`0072f9d8,
+			struct PRLock * lock = 0x00000000`0041bcb0,
+			unsigned int timeout = 0x4307a0)+0x66 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\prucv.c @ 173]
+04 00000000`038ef950 000007fe`f869abd0 js_64_prof_windows_a523d4c7efe2!js::HelperThread::threadLoop(void)+0x246 [c:\users\mozillaadmin\trees\mozilla-central\js\src\vm\helperthreads.cpp @ 1596]
+05 00000000`038ef980 000007fe`f869c17a nspr4!_PR_NativeRunThread(
+			void * arg = 0x00000000`0042e740)+0x100 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\pruthr.c @ 419]
+06 00000000`038ef9b0 000007fe`f8744f7f nspr4!pr_root(
+			void * arg = 0x00000000`004307a0)+0xa [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95thred.c @ 91]
+07 00000000`038ef9e0 000007fe`f8745126 msvcr120!beginthreadex+0x107
+08 00000000`038efa10 00000000`773359dd msvcr120!endthreadex+0x192
+09 00000000`038efa40 00000000`7746a631 kernel32!BaseThreadInitThunk+0xd
+0a 00000000`038efa70 00000000`00000000 ntdll!RtlUserThreadStart+0x21
+
+   7  Id: 9d0.abc Suspend: 1 Teb: 000007ff`fffac000 Unfrozen
+ # Child-SP          RetAddr           Call Site
+00 00000000`03cdfb88 000007fe`fd2010dc ntdll!ZwWaitForSingleObject+0xa
+01 00000000`03cdfb90 000007fe`f869d2e8 KERNELBASE!WaitForSingleObjectEx+0x9c
+02 00000000`03cdfc30 000007fe`f8699296 nspr4!_PR_MD_WAIT_CV(
+			struct _MDCVar * cv = 0x00000000`00430c20,
+			struct _MDLock * lock = 0x00000000`00000002,
+			unsigned int timeout = 0x72fbd0)+0xa8 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95cv.c @ 250]
+03 00000000`03cdfc60 00000001`3fdaa646 nspr4!_PR_WaitCondVar(
+			struct PRThread * thread = 0x00000000`00706180,
+			struct PRCondVar * cvar = 0x00000000`0072fbd0,
+			struct PRLock * lock = 0x00000000`0041bcb0,
+			unsigned int timeout = 0x430eb0)+0x66 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\prucv.c @ 173]
+04 00000000`03cdfc90 000007fe`f869abd0 js_64_prof_windows_a523d4c7efe2!js::HelperThread::threadLoop(void)+0x246 [c:\users\mozillaadmin\trees\mozilla-central\js\src\vm\helperthreads.cpp @ 1596]
+05 00000000`03cdfcc0 000007fe`f869c17a nspr4!_PR_NativeRunThread(
+			void * arg = 0x00000000`00430e50)+0x100 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\pruthr.c @ 419]
+06 00000000`03cdfcf0 000007fe`f8744f7f nspr4!pr_root(
+			void * arg = 0x00000000`00430eb0)+0xa [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95thred.c @ 91]
+07 00000000`03cdfd20 000007fe`f8745126 msvcr120!beginthreadex+0x107
+08 00000000`03cdfd50 00000000`773359dd msvcr120!endthreadex+0x192
+09 00000000`03cdfd80 00000000`7746a631 kernel32!BaseThreadInitThunk+0xd
+0a 00000000`03cdfdb0 00000000`00000000 ntdll!RtlUserThreadStart+0x21
+
+   8  Id: 9d0.1e4 Suspend: 1 Teb: 000007ff`fffaa000 Unfrozen
+ # Child-SP          RetAddr           Call Site
+00 00000000`040af8c8 000007fe`fd2010dc ntdll!ZwWaitForSingleObject+0xa
+01 00000000`040af8d0 000007fe`f869d2e8 KERNELBASE!WaitForSingleObjectEx+0x9c
+02 00000000`040af970 000007fe`f8699296 nspr4!_PR_MD_WAIT_CV(
+			struct _MDCVar * cv = 0x00000000`00431330,
+			struct _MDLock * lock = 0x00000000`00000002,
+			unsigned int timeout = 0x72fdc8)+0xa8 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95cv.c @ 250]
+03 00000000`040af9a0 00000001`3fdaa646 nspr4!_PR_WaitCondVar(
+			struct PRThread * thread = 0x00000000`00706180,
+			struct PRCondVar * cvar = 0x00000000`0072fdc8,
+			struct PRLock * lock = 0x00000000`0041bcb0,
+			unsigned int timeout = 0x4315c0)+0x66 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\prucv.c @ 173]
+04 00000000`040af9d0 000007fe`f869abd0 js_64_prof_windows_a523d4c7efe2!js::HelperThread::threadLoop(void)+0x246 [c:\users\mozillaadmin\trees\mozilla-central\js\src\vm\helperthreads.cpp @ 1596]
+05 00000000`040afa00 000007fe`f869c17a nspr4!_PR_NativeRunThread(
+			void * arg = 0x00000000`00431560)+0x100 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\pruthr.c @ 419]
+06 00000000`040afa30 000007fe`f8744f7f nspr4!pr_root(
+			void * arg = 0x00000000`004315c0)+0xa [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95thred.c @ 91]
+07 00000000`040afa60 000007fe`f8745126 msvcr120!beginthreadex+0x107
+08 00000000`040afa90 00000000`773359dd msvcr120!endthreadex+0x192
+09 00000000`040afac0 00000000`7746a631 kernel32!BaseThreadInitThunk+0xd
+0a 00000000`040afaf0 00000000`00000000 ntdll!RtlUserThreadStart+0x21
+
+   9  Id: 9d0.11ac Suspend: 1 Teb: 000007ff`fffa8000 Unfrozen
+ # Child-SP          RetAddr           Call Site
+00 00000000`043dfcb8 000007fe`fd2010dc ntdll!ZwWaitForSingleObject+0xa
+01 00000000`043dfcc0 000007fe`f869d2e8 KERNELBASE!WaitForSingleObjectEx+0x9c
+02 00000000`043dfd60 000007fe`f8699296 nspr4!_PR_MD_WAIT_CV(
+			struct _MDCVar * cv = 0x00000000`00431a40,
+			struct _MDLock * lock = 0x00000000`00000002,
+			unsigned int timeout = 0x72ffc0)+0xa8 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95cv.c @ 250]
+03 00000000`043dfd90 00000001`3fdaa646 nspr4!_PR_WaitCondVar(
+			struct PRThread * thread = 0x00000000`00706180,
+			struct PRCondVar * cvar = 0x00000000`0072ffc0,
+			struct PRLock * lock = 0x00000000`0041bcb0,
+			unsigned int timeout = 0x431cd0)+0x66 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\prucv.c @ 173]
+04 00000000`043dfdc0 000007fe`f869abd0 js_64_prof_windows_a523d4c7efe2!js::HelperThread::threadLoop(void)+0x246 [c:\users\mozillaadmin\trees\mozilla-central\js\src\vm\helperthreads.cpp @ 1596]
+05 00000000`043dfdf0 000007fe`f869c17a nspr4!_PR_NativeRunThread(
+			void * arg = 0x00000000`00431c70)+0x100 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\pruthr.c @ 419]
+06 00000000`043dfe20 000007fe`f8744f7f nspr4!pr_root(
+			void * arg = 0x00000000`00431cd0)+0xa [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95thred.c @ 91]
+07 00000000`043dfe50 000007fe`f8745126 msvcr120!beginthreadex+0x107
+08 00000000`043dfe80 00000000`773359dd msvcr120!endthreadex+0x192
+09 00000000`043dfeb0 00000000`7746a631 kernel32!BaseThreadInitThunk+0xd
+0a 00000000`043dfee0 00000000`00000000 ntdll!RtlUserThreadStart+0x21
+
+  10  Id: 9d0.9ac Suspend: 1 Teb: 000007ff`fffa6000 Unfrozen
+ # Child-SP          RetAddr           Call Site
+00 00000000`0475f6e8 000007fe`fd2010dc ntdll!ZwWaitForSingleObject+0xa
+01 00000000`0475f6f0 000007fe`f869d2e8 KERNELBASE!WaitForSingleObjectEx+0x9c
+02 00000000`0475f790 000007fe`f8699296 nspr4!_PR_MD_WAIT_CV(
+			struct _MDCVar * cv = 0x00000000`00432150,
+			struct _MDLock * lock = 0x00000000`00000002,
+			unsigned int timeout = 0x7301b8)+0xa8 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95cv.c @ 250]
+03 00000000`0475f7c0 00000001`3fdaa646 nspr4!_PR_WaitCondVar(
+			struct PRThread * thread = 0x00000000`00706180,
+			struct PRCondVar * cvar = 0x00000000`007301b8,
+			struct PRLock * lock = 0x00000000`0041bcb0,
+			unsigned int timeout = 0x4323e0)+0x66 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\prucv.c @ 173]
+04 00000000`0475f7f0 000007fe`f869abd0 js_64_prof_windows_a523d4c7efe2!js::HelperThread::threadLoop(void)+0x246 [c:\users\mozillaadmin\trees\mozilla-central\js\src\vm\helperthreads.cpp @ 1596]
+05 00000000`0475f820 000007fe`f869c17a nspr4!_PR_NativeRunThread(
+			void * arg = 0x00000000`00432380)+0x100 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\pruthr.c @ 419]
+06 00000000`0475f850 000007fe`f8744f7f nspr4!pr_root(
+			void * arg = 0x00000000`004323e0)+0xa [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95thred.c @ 91]
+07 00000000`0475f880 000007fe`f8745126 msvcr120!beginthreadex+0x107
+08 00000000`0475f8b0 00000000`773359dd msvcr120!endthreadex+0x192
+09 00000000`0475f8e0 00000000`7746a631 kernel32!BaseThreadInitThunk+0xd
+0a 00000000`0475f910 00000000`00000000 ntdll!RtlUserThreadStart+0x21
+
+  11  Id: 9d0.91c Suspend: 1 Teb: 000007ff`fffa4000 Unfrozen
+ # Child-SP          RetAddr           Call Site
+00 00000000`0496f578 000007fe`fd2010dc ntdll!ZwWaitForSingleObject+0xa
+01 00000000`0496f580 000007fe`f869d2e8 KERNELBASE!WaitForSingleObjectEx+0x9c
+02 00000000`0496f620 000007fe`f8699296 nspr4!_PR_MD_WAIT_CV(
+			struct _MDCVar * cv = 0x00000000`0042c090,
+			struct _MDLock * lock = 0x00000000`00000002,
+			unsigned int timeout = 0x7303b0)+0xa8 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95cv.c @ 250]
+03 00000000`0496f650 00000001`3fdaa646 nspr4!_PR_WaitCondVar(
+			struct PRThread * thread = 0x00000000`00706180,
+			struct PRCondVar * cvar = 0x00000000`007303b0,
+			struct PRLock * lock = 0x00000000`0041bcb0,
+			unsigned int timeout = 0x433100)+0x66 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\prucv.c @ 173]
+04 00000000`0496f680 000007fe`f869abd0 js_64_prof_windows_a523d4c7efe2!js::HelperThread::threadLoop(void)+0x246 [c:\users\mozillaadmin\trees\mozilla-central\js\src\vm\helperthreads.cpp @ 1596]
+05 00000000`0496f6b0 000007fe`f869c17a nspr4!_PR_NativeRunThread(
+			void * arg = 0x00000000`0042c2c0)+0x100 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\pruthr.c @ 419]
+06 00000000`0496f6e0 000007fe`f8744f7f nspr4!pr_root(
+			void * arg = 0x00000000`00433100)+0xa [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95thred.c @ 91]
+07 00000000`0496f710 000007fe`f8745126 msvcr120!beginthreadex+0x107
+08 00000000`0496f740 00000000`773359dd msvcr120!endthreadex+0x192
+09 00000000`0496f770 00000000`7746a631 kernel32!BaseThreadInitThunk+0xd
+0a 00000000`0496f7a0 00000000`00000000 ntdll!RtlUserThreadStart+0x21
+
+  12  Id: 9d0.1254 Suspend: 1 Teb: 000007ff`fffa2000 Unfrozen
+ # Child-SP          RetAddr           Call Site
+00 00000000`04b6f598 000007fe`fd2010dc ntdll!ZwWaitForSingleObject+0xa
+01 00000000`04b6f5a0 000007fe`f869d2e8 KERNELBASE!WaitForSingleObjectEx+0x9c
+02 00000000`04b6f640 000007fe`f8699296 nspr4!_PR_MD_WAIT_CV(
+			struct _MDCVar * cv = 0x00000000`0042e090,
+			struct _MDLock * lock = 0x00000000`00000002,
+			unsigned int timeout = 0x7305a8)+0xa8 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95cv.c @ 250]
+03 00000000`04b6f670 00000001`3fdaa646 nspr4!_PR_WaitCondVar(
+			struct PRThread * thread = 0x00000000`00706180,
+			struct PRCondVar * cvar = 0x00000000`007305a8,
+			struct PRLock * lock = 0x00000000`0041bcb0,
+			unsigned int timeout = 0x434e20)+0x66 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\prucv.c @ 173]
+04 00000000`04b6f6a0 000007fe`f869abd0 js_64_prof_windows_a523d4c7efe2!js::HelperThread::threadLoop(void)+0x246 [c:\users\mozillaadmin\trees\mozilla-central\js\src\vm\helperthreads.cpp @ 1596]
+05 00000000`04b6f6d0 000007fe`f869c17a nspr4!_PR_NativeRunThread(
+			void * arg = 0x00000000`00433e50)+0x100 [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\threads\combined\pruthr.c @ 419]
+06 00000000`04b6f700 000007fe`f8744f7f nspr4!pr_root(
+			void * arg = 0x00000000`00434e20)+0xa [c:\users\mozillaadmin\trees\mozilla-central\nsprpub\pr\src\md\windows\w95thred.c @ 91]
+07 00000000`04b6f730 000007fe`f8745126 msvcr120!beginthreadex+0x107
+08 00000000`04b6f760 00000000`773359dd msvcr120!endthreadex+0x192
+09 00000000`04b6f790 00000000`7746a631 kernel32!BaseThreadInitThunk+0xd
+0a 00000000`04b6f7c0 00000000`00000000 ntdll!RtlUserThreadStart+0x21
 0:000> q
 quit:

--- a/FTB/Signatures/cdb-crash-report-example-1.txt
+++ b/FTB/Signatures/cdb-crash-report-example-1.txt
@@ -1,0 +1,120 @@
+
+Microsoft (R) Windows Debugger Version 6.12.0002.633 AMD64
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+
+Loading Dump File [c:\Users\mozillaadmin\AppData\Local\CrashDumps\js-64-prof-windows-a523d4c7efe2.exe.2512.dmp]
+User Mini Dump File: Only registers, stack and portions of memory are available
+
+Symbol search path is: *** Invalid ***
+****************************************************************************
+* Symbol loading may be unreliable without a symbol search path.           *
+* Use .symfix to have the debugger choose a symbol path.                   *
+* After setting your symbol path, use .reload to refresh symbol locations. *
+****************************************************************************
+Executable search path is:
+Windows 7 Version 7601 (Service Pack 1) MP (8 procs) Free x64
+Product: WinNt, suite: SingleUserTS
+Machine Name:
+Debug session time: Thu Nov 19 15:45:03.000 2015 (UTC - 8:00)
+System Uptime: not available
+Process Uptime: 0 days 0:00:07.000
+..........................
+This dump file has a breakpoint exception stored in it.
+The stored exception information can be accessed via .ecxr.
+*** WARNING: Unable to verify checksum for mozglue.dll
+mozglue!moz_abort+0x4:
+000007fe`f86c13e4 cc              int     3
+0:000> cdb: Reading initial command '.load C:\Program Files\Debugging Tools for Windows (x64)\winext\msec.dll;$<c:\Users\mozillaadmin\funfuzz\util\cdbCmds.txt'
+0:000> .echo Display lines in stack trace
+Display lines in stack trace
+0:000> .lines
+Line number information will be loaded
+0:000> ~kn 250
+ # Child-SP          RetAddr           Call Site
+00 00000000`0033bb10 000007fe`f86c45cd mozglue!moz_abort+0x4 [c:\users\mozillaadmin\trees\mozilla-central\memory\build\jemalloc_config.cpp @ 159]
+01 00000000`0033bb40 000007fe`f86c3de3 mozglue!arena_run_split+0x27d [c:\users\mozillaadmin\trees\mozilla-central\memory\mozjemalloc\jemalloc.c @ 3481]
+02 00000000`0033bbd0 000007fe`f86c2f79 mozglue!arena_run_alloc+0x103 [c:\users\mozillaadmin\trees\mozilla-central\memory\mozjemalloc\jemalloc.c @ 3651]
+03 00000000`0033bc40 000007fe`f86c39bd mozglue!arena_malloc_large+0x49 [c:\users\mozillaadmin\trees\mozilla-central\memory\mozjemalloc\jemalloc.c @ 4254]
+04 00000000`0033bc80 000007fe`f86c75fd mozglue!arena_ralloc+0x25d [c:\users\mozillaadmin\trees\mozilla-central\memory\mozjemalloc\jemalloc.c @ 4891]
+*** WARNING: Unable to verify checksum for js-64-prof-windows-a523d4c7efe2.exe
+05 00000000`0033bcb0 00000001`3fb93053 mozglue!je_realloc+0x3d [c:\users\mozillaadmin\trees\mozilla-central\memory\mozjemalloc\jemalloc.c @ 6404]
+06 00000000`0033bce0 00000001`3fb99695 js_64_prof_windows_a523d4c7efe2!mozilla::VectorBase<unsigned char,256,js::SystemAllocPolicy,mozilla::Vector<unsigned char,256,js::SystemAllocPolicy> >::growStorageBy+0x53 [c:\users\mozillaadmin\shell-cache\js-64-prof-windows-a523d4c7efe2\objdir-js\dist\include\mozilla\vector.h @ 885]
+07 00000000`0033bd10 00000001`3fb98d1d js_64_prof_windows_a523d4c7efe2!js::jit::X86Encoding::BaseAssembler::X86InstructionFormatter::oneByteOp64+0x35 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\x86-shared\baseassembler-x86-shared.h @ 4341]
+08 00000000`0033bd40 00000001`3ff3d872 js_64_prof_windows_a523d4c7efe2!js::jit::X86Encoding::BaseAssemblerX64::movq_mr+0x7d [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\x64\baseassembler-x64.h @ 469]
+09 00000000`0033bd80 00000001`3ff4684c js_64_prof_windows_a523d4c7efe2!js::jit::MacroAssemblerX64::load64+0xd2 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\x64\macroassembler-x64.h @ 774]
+0a 00000000`0033bdc0 00000001`3ff38968 js_64_prof_windows_a523d4c7efe2!js::jit::CodeGenerator::visitElements+0x4c [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\codegenerator.cpp @ 2579]
+0b 00000000`0033bdf0 00000001`3ff381a2 js_64_prof_windows_a523d4c7efe2!js::jit::CodeGenerator::generateBody+0x258 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\codegenerator.cpp @ 4173]
+0c 00000000`0033bea0 00000001`3fe88759 js_64_prof_windows_a523d4c7efe2!js::jit::CodeGenerator::generate+0x162 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\codegenerator.cpp @ 7893]
+0d 00000000`0033bed0 00000001`3fe8cc46 js_64_prof_windows_a523d4c7efe2!js::jit::GenerateCode+0xd9 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\ion.cpp @ 1961]
+0e 00000000`0033bf20 00000001`3fe83398 js_64_prof_windows_a523d4c7efe2!js::jit::IonCompile+0xb86 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\ion.cpp @ 2249]
+0f 00000000`0033c270 00000001`3fe8351a js_64_prof_windows_a523d4c7efe2!js::jit::Compile+0x1a8 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\ion.cpp @ 2419]
+10 00000000`0033c330 00000001`3ffa43d5 js_64_prof_windows_a523d4c7efe2!js::jit::CompileFunctionForBaseline+0x9a [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\ion.cpp @ 2612]
+11 00000000`0033c370 00000001`3ffa404b js_64_prof_windows_a523d4c7efe2!js::jit::EnsureCanEnterIon+0x45 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\baselineic.cpp @ 69]
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for ntdll.dll -
+12 00000000`0033c3a0 00000109`f77b2630 js_64_prof_windows_a523d4c7efe2!js::jit::DoWarmUpCounterFallback+0xeb [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\baselineic.cpp @ 230]
+13 00000000`0033c410 00000000`00000000 0x109`f77b2630
+0:000> .echo .ecxr switches to the exception context frame
+.ecxr switches to the exception context frame
+0:000> .ecxr
+rax=0000000000000000 rbx=0000000000008000 rcx=00000000000005af
+rdx=0000000000000000 rsi=0000000008c52000 rdi=0000000000008000
+rip=000007fef86c13e4 rsp=000000000033bb10 rbp=0000000000000008
+ r8=0000000077440000  r9=00000000000003a6 r10=00000000c000012d
+r11=0000000000000246 r12=0000000000000008 r13=0000000000500040
+r14=0000000008c007e0 r15=0000000000000000
+iopl=0         nv up ei pl nz na pe nc
+cs=0033  ss=002b  ds=002b  es=002b  fs=0053  gs=002b             efl=00000200
+mozglue!moz_abort+0x4:
+000007fe`f86c13e4 cc              int     3
+0:000> !exploitable -v
+
+!exploitable 1.6.0.0
+HostMachine\HostUser
+Executing Processor Architecture is x64
+Debuggee is in User Mode
+Debuggee is a user mode small dump file
+Event Type: Exception
+Exception Faulting Address: 0x7fef86c13e4
+Second Chance Exception Type: STATUS_BREAKPOINT (0x80000003)
+
+Faulting Instruction:000007fe`f86c13e4 int 3
+
+Basic Block:
+    000007fe`f86c13e4 int 3
+
+Exception Hash (Major/Minor): 0xc3eefb5e.0x784ac7be
+
+ Hash Usage : Stack Trace:
+Major+Minor : mozglue!moz_abort+0x4
+Major+Minor : mozglue!arena_run_split+0x27d
+Major+Minor : mozglue!arena_run_alloc+0x103
+Major+Minor : mozglue!arena_malloc_large+0x49
+Major+Minor : mozglue!arena_ralloc+0x25d
+Minor       : mozglue!je_realloc+0x3d
+Minor       : js_64_prof_windows_a523d4c7efe2!mozilla::VectorBase<unsigned char,256,js::SystemAllocPolicy,mozilla::Vector<unsigned char,256,j+0x53
+Minor       : js_64_prof_windows_a523d4c7efe2!js::jit::X86Encoding::BaseAssembler::X86InstructionFormatter::oneByteOp64+0x35
+Minor       : js_64_prof_windows_a523d4c7efe2!js::jit::X86Encoding::BaseAssemblerX64::movq_mr+0x7d
+Minor       : js_64_prof_windows_a523d4c7efe2!js::jit::MacroAssemblerX64::load64+0xd2
+Minor       : js_64_prof_windows_a523d4c7efe2!js::jit::CodeGenerator::visitElements+0x4c
+Minor       : js_64_prof_windows_a523d4c7efe2!js::jit::CodeGenerator::generateBody+0x258
+Minor       : js_64_prof_windows_a523d4c7efe2!js::jit::CodeGenerator::generate+0x162
+Minor       : js_64_prof_windows_a523d4c7efe2!js::jit::GenerateCode+0xd9
+Minor       : js_64_prof_windows_a523d4c7efe2!js::jit::IonCompile+0xb86
+Minor       : js_64_prof_windows_a523d4c7efe2!js::jit::Compile+0x1a8
+Minor       : js_64_prof_windows_a523d4c7efe2!js::jit::CompileFunctionForBaseline+0x9a
+Minor       : js_64_prof_windows_a523d4c7efe2!js::jit::EnsureCanEnterIon+0x45
+Minor       : js_64_prof_windows_a523d4c7efe2!js::jit::DoWarmUpCounterFallback+0xeb
+Minor       : Unknown
+Instruction Address: 0x000007fef86c13e4
+Source File: c:\users\mozillaadmin\trees\mozilla-central\memory\build\jemalloc_config.cpp
+Source Line: 159
+
+Description: Possible Stack Corruption
+Short Description: PossibleStackCorruption
+Exploitability Classification: UNKNOWN
+Recommended Bug Title: Possible Stack Corruption starting at mozglue!moz_abort+0x0000000000000004 (Hash=0xc3eefb5e.0x784ac7be)
+
+The stack trace contains one or more locations for which no symbol or module could be found. This may be a sign of stack corruption.
+0:000> q
+quit:

--- a/FTB/Signatures/cdb-crash-report-example-2.txt
+++ b/FTB/Signatures/cdb-crash-report-example-2.txt
@@ -1,0 +1,147 @@
+
+Microsoft (R) Windows Debugger Version 6.12.0002.633 AMD64
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+
+Loading Dump File [c:\Users\mozillaadmin\AppData\Local\CrashDumps\js-dbg-64-prof-dm-windows-388bdc46ba51.exe.4568.dmp]
+User Mini Dump File: Only registers, stack and portions of memory are available
+
+Symbol search path is: *** Invalid ***
+****************************************************************************
+* Symbol loading may be unreliable without a symbol search path.           *
+* Use .symfix to have the debugger choose a symbol path.                   *
+* After setting your symbol path, use .reload to refresh symbol locations. *
+****************************************************************************
+Executable search path is:
+Windows 7 Version 7601 (Service Pack 1) MP (8 procs) Free x64
+Product: WinNt, suite: SingleUserTS
+Machine Name:
+Debug session time: Sun Dec 20 00:55:36.000 2015 (UTC - 8:00)
+System Uptime: not available
+Process Uptime: 0 days 0:00:12.000
+..........................
+This dump file has a breakpoint exception stored in it.
+The stored exception information can be accessed via .ecxr.
+*** WARNING: Unable to verify checksum for js-dbg-64-prof-dm-windows-388bdc46ba51.exe
+js_dbg_64_prof_dm_windows_388bdc46ba51!js::jit::DoTypeMonitorFallback+0x383:
+00000001`405e4703 cc              int     3
+0:000> cdb: Reading initial command '.load C:\Program Files\Debugging Tools for Windows (x64)\winext\msec.dll;$<c:\Users\mozillaadmin\funfuzz\util\cdbCmds.txt'
+0:000> .echo Toggle for 32-bit/64-bit modes
+Toggle for 32-bit/64-bit modes
+0:000> .echo See http://people.mozilla.org/~aklotz/windbgcheatsheet.html
+See http://people.mozilla.org/~aklotz/windbgcheatsheet.html
+0:000> !wow64exts.sw
+The current thread doesn't have an x86 context.
+0:000> .echo Display lines in stack trace
+Display lines in stack trace
+0:000> .lines
+Line number information will be loaded
+0:000> .echo .ecxr switches to the exception context frame
+.ecxr switches to the exception context frame
+0:000> .ecxr
+rax=0000000000000000 rbx=00000000072f5220 rcx=000007fef884b780
+rdx=0000000000000000 rsi=0000000002016400 rdi=00000000071eb5bc
+rip=00000001405e4703 rsp=00000000003ecb80 rbp=00000000003ecbd0
+ r8=00000000003e8c48  r9=00000000003ecbd0 r10=0000000000000000
+r11=0000000000000246 r12=0000000000000008 r13=0000000000000000
+r14=00000000003ecc68 r15=0000000000000000
+iopl=0         nv up ei pl nz na po nc
+cs=0033  ss=002b  ds=002b  es=002b  fs=0053  gs=002b             efl=00000204
+js_dbg_64_prof_dm_windows_388bdc46ba51!js::jit::DoTypeMonitorFallback+0x383:
+00000001`405e4703 cc              int     3
+0:000> .echo Inspect program counter, equivalent of gdb's "x/i $pc"
+Inspect program counter, equivalent of gdb's "x/i $pc"
+0:000> u
+js_dbg_64_prof_dm_windows_388bdc46ba51!js::jit::DoTypeMonitorFallback+0x383 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\sharedic.cpp @ 4737]:
+00000001`405e4703 cc              int     3
+00000001`405e4704 c704250000000081120000 mov dword ptr [0],1281h
+00000001`405e470f ff15f3187a00    call    qword ptr [js_dbg_64_prof_dm_windows_388bdc46ba51!_imp_GetCurrentProcess (00000001`40d86008)]
+00000001`405e4715 ba03000000      mov     edx,3
+00000001`405e471a 488bc8          mov     rcx,rax
+00000001`405e471d ff15b5197a00    call    qword ptr [js_dbg_64_prof_dm_windows_388bdc46ba51!_imp_TerminateProcess (00000001`40d860d8)]
+00000001`405e4723 cc              int     3
+00000001`405e4724 488b4d38        mov     rcx,qword ptr [rbp+38h]
+0:000> .echo Inspect eip (32-bit) register, equivalent of gdb's "x/b $eax"
+Inspect eip (32-bit) register, equivalent of gdb's "x/b $eax"
+0:000> db @@c++(@eip) L4
+00000000`405e4703  ?? ?? ?? ??                                      ????
+0:000> .echo Inspect rip (64-bit) register, equivalent of gdb's "x/b $rax"
+Inspect rip (64-bit) register, equivalent of gdb's "x/b $rax"
+0:000> db @@c++(@rip) L8
+00000001`405e4703  cc c7 04 25 00 00 00 00                          ...%....
+0:000> .echo To switch frames: .frame /r /c <frame number>
+To switch frames: .frame /r /c <frame number>
+0:000> .echo Then inspect locals using: dv <locals in this frame>
+Then inspect locals using: dv <locals in this frame>
+0:000> .echo Running !exploitable
+Running !exploitable
+0:000> !exploitable -v
+
+!exploitable 1.6.0.0
+HostMachine\HostUser
+Executing Processor Architecture is x64
+Debuggee is in User Mode
+Debuggee is a user mode small dump file
+Event Type: Exception
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for ntdll.dll -
+Exception Faulting Address: 0x1405e4703
+Second Chance Exception Type: STATUS_BREAKPOINT (0x80000003)
+
+Faulting Instruction:00000001`405e4703 int 3
+
+Basic Block:
+    00000001`405e4703 int 3
+
+Exception Hash (Major/Minor): 0xf716ca08.0xa10fe43c
+
+ Hash Usage : Stack Trace:
+Major+Minor : js_dbg_64_prof_dm_windows_388bdc46ba51!js::jit::DoTypeMonitorFallback+0x383
+Major+Minor : Unknown
+Major+Minor : Unknown
+Major+Minor : Unknown
+Major+Minor : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : js_dbg_64_prof_dm_windows_388bdc46ba51!DoTypeMonitorFallbackInfo+0x0
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Instruction Address: 0x00000001405e4703
+Source File: c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\sharedic.cpp
+Source Line: 4737
+
+Description: Possible Stack Corruption
+Short Description: PossibleStackCorruption
+Exploitability Classification: UNKNOWN
+Recommended Bug Title: Possible Stack Corruption starting at js_dbg_64_prof_dm_windows_388bdc46ba51!js::jit::DoTypeMonitorFallback+0x0000000000000383 (Hash=0xf716ca08.0xa10fe43c)
+
+The stack trace contains one or more locations for which no symbol or module could be found. This may be a sign of stack corruption.
+0:000> .echo Backtrace of faulting thread, limited to 250 frames
+Backtrace of faulting thread, limited to 250 frames
+0:000> ~#kn 250
+ # Child-SP          RetAddr           Call Site
+00 00000000`003ecb80 00000358`fcbe3c9f js_dbg_64_prof_dm_windows_388bdc46ba51!js::jit::DoTypeMonitorFallback+0x383 [c:\users\mozillaadmin\trees\mozilla-central\js\src\jit\sharedic.cpp @ 4737]
+01 00000000`003ecbf0 00000325`f0a8ddd4 0x358`fcbe3c9f
+02 00000000`003ecbf8 000002e5`c572e88b 0x325`f0a8ddd4
+03 00000000`003ecc00 00000000`072f5220 0x2e5`c572e88b
+04 00000000`003ecc08 00000000`003ecc60 0x72f5220
+05 00000000`003ecc10 00000000`003ecc28 0x3ecc60
+06 00000000`003ecc18 00000000`003ecc28 0x3ecc28
+07 00000000`003ecc20 00000000`04fb0ff8 0x3ecc28
+08 00000000`003ecc28 fff90000`00000000 0x4fb0ff8
+09 00000000`003ecc30 00000001`40ccd800 0xfff90000`00000000
+0a 00000000`003ecc38 00000000`05f59d30 js_dbg_64_prof_dm_windows_388bdc46ba51!DoTypeMonitorFallbackInfo
+0b 00000000`003ecc40 000002e5`c572e88b 0x5f59d30
+0c 00000000`003ecc48 00000000`00000c01 0x2e5`c572e88b
+0d 00000000`003ecc50 00000000`003ecc68 0xc01
+0e 00000000`003ecc58 00000000`072f5220 0x3ecc68
+0f 00000000`003ecc60 fffa0000`00000010 0x72f5220
+10 00000000`003ecc68 00000000`00000000 0xfffa0000`00000010
+0:000> q
+quit:

--- a/FTB/Signatures/cdb-crash-report-example-3.txt
+++ b/FTB/Signatures/cdb-crash-report-example-3.txt
@@ -1,0 +1,176 @@
+
+Microsoft (R) Windows Debugger Version 6.12.0002.633 AMD64
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+
+Loading Dump File [c:\Users\fuzz1win\AppData\Local\CrashDumps\js-dbg-32-prof-dm-windows-388bdc46ba51.exe.4228.dmp]
+User Mini Dump File: Only registers, stack and portions of memory are available
+
+Symbol search path is: *** Invalid ***
+****************************************************************************
+* Symbol loading may be unreliable without a symbol search path.           *
+* Use .symfix to have the debugger choose a symbol path.                   *
+* After setting your symbol path, use .reload to refresh symbol locations. *
+****************************************************************************
+Executable search path is:
+Windows 7 Version 7601 (Service Pack 1) MP (8 procs) Free x86 compatible
+Product: WinNt, suite: SingleUserTS
+Machine Name:
+Debug session time: Mon Dec 21 03:14:14.000 2015 (UTC - 8:00)
+System Uptime: not available
+Process Uptime: 0 days 0:00:21.000
+...........................
+This dump file has a breakpoint exception stored in it.
+The stored exception information can be accessed via .ecxr.
+eax=00000000 ebx=0020ce04 ecx=12630a6d edx=00000012 esi=00000002 edi=00000000
+eip=779a015d esp=0020cdb4 ebp=0020ce50 iopl=0         nv up ei pl zr na pe nc
+cs=0023  ss=002b  ds=002b  es=002b  fs=0053  gs=002b             efl=00000246
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for ntdll.dll -
+ntdll!NtWaitForMultipleObjects+0x15:
+779a015d 83c404          add     esp,4
+0:000> cdb: Reading initial command '.load C:\Program Files\Debugging Tools for Windows (x64)\winext\msec.dll;$<c:\Users\fuzz1win\funfuzz\util\cdbCmds.txt'
+0:000> .echo Toggle for 32-bit/64-bit modes
+Toggle for 32-bit/64-bit modes
+0:000> .echo See http://people.mozilla.org/~aklotz/windbgcheatsheet.html
+See http://people.mozilla.org/~aklotz/windbgcheatsheet.html
+0:000> !wow64exts.sw
+!wow64exts.sw : command invalid on non-64bit target
+0:000> .echo Display lines in stack trace
+Display lines in stack trace
+0:000> .lines
+Line number information will be loaded
+0:000> .echo .ecxr switches to the exception context frame
+.ecxr switches to the exception context frame
+0:000> .ecxr
+eax=00000000 ebx=00000000 ecx=12630a6d edx=00000012 esi=00c6b180 edi=00000000
+eip=01206fbd esp=0020d5b4 ebp=0020d5bc iopl=0         nv up ei pl nz ac pe nc
+cs=0023  ss=002b  ds=002b  es=002b  fs=0053  gs=002b             efl=00000216
+*** WARNING: Unable to verify checksum for js-dbg-32-prof-dm-windows-388bdc46ba51.exe
+js_dbg_32_prof_dm_windows_388bdc46ba51!JS::Value::isMagic+0x4d:
+01206fbd cc              int     3
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for ntdll.dll -
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for kernel32.dll -
+0:000> .echo Inspect program counter, equivalent of gdb's "x/i $pc"
+Inspect program counter, equivalent of gdb's "x/i $pc"
+0:000> u
+ntdll!NtWaitForMultipleObjects+0x15:
+779a015d 83c404          add     esp,4
+779a0160 c21400          ret     14h
+779a0163 90              nop
+ntdll!NtSetInformationObject:
+779a0164 b859000000      mov     eax,59h
+779a0169 33c9            xor     ecx,ecx
+779a016b 8d542404        lea     edx,[esp+4]
+779a016f 64ff15c0000000  call    dword ptr fs:[0C0h]
+779a0176 83c404          add     esp,4
+0:000> .echo Inspect eip (32-bit) register, equivalent of gdb's "x/b $eax"
+Inspect eip (32-bit) register, equivalent of gdb's "x/b $eax"
+0:000> db @@c++(@eip) L4
+01206fbd  cc 6a 03 c7                                      .j..
+0:000> .echo Inspect rip (64-bit) register, equivalent of gdb's "x/b $rax"
+Inspect rip (64-bit) register, equivalent of gdb's "x/b $rax"
+0:000> db @@c++(@rip) L8
+Bad register error at '@rip) '
+0:000> .echo To switch frames: .frame /r /c <frame number>
+To switch frames: .frame /r /c <frame number>
+0:000> .echo Then inspect locals using: dv <locals in this frame>
+Then inspect locals using: dv <locals in this frame>
+0:000> .echo Running !exploitable
+Running !exploitable
+0:000> !exploitable -v
+
+!exploitable 1.6.0.0
+HostMachine\HostUser
+Executing Processor Architecture is x86
+Debuggee is in User Mode
+Debuggee is a user mode small dump file
+Event Type: Exception
+Exception Faulting Address: 0x1206fbd
+Second Chance Exception Type: STATUS_BREAKPOINT (0x80000003)
+
+Faulting Instruction:01206fbd int 3
+
+Basic Block:
+    01206fbd int 3
+
+Exception Hash (Major/Minor): 0x815301b3.0x762bfe25
+
+ Hash Usage : Stack Trace:
+Major+Minor : js_dbg_32_prof_dm_windows_388bdc46ba51!JS::Value::isMagic+0x4d
+Major+Minor : js_dbg_32_prof_dm_windows_388bdc46ba51!js::jit::InvokeFunction+0x1be
+Major+Minor : Unknown
+Major+Minor : js_dbg_32_prof_dm_windows_388bdc46ba51!EnterIon+0x203
+Major+Minor : js_dbg_32_prof_dm_windows_388bdc46ba51!js::jit::IonCannon+0x110
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::RunScript+0x12c
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::Invoke+0x397
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::Invoke+0x1ad
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::jit::InvokeFunction+0x26c
+Minor       : Unknown
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!EnterIon+0x203
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::jit::IonCannon+0x110
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!Interpret+0x9fbc
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::RunScript+0x267
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::ExecuteKernel+0x2ac
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::Execute+0x1be
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!Evaluate+0x289
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!Evaluate+0x93
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!JS::Evaluate+0x17
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!EvalInContext+0x297
+Minor       : Unknown
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!Print+0x38
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::Activation::Activation+0xee
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!EnterIon+0x203
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::jit::IonCannon+0x110
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::RunScript+0x12c
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::Invoke+0x397
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::Invoke+0x1ad
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::jit::DoCallFallback+0x5fd
+Minor       : Unknown
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!EnterBaseline+0x2a8
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::jit::EnterBaselineMethod+0x110
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::RunScript+0x1d8
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::ExecuteKernel+0x2ac
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!js::Execute+0x1be
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!ExecuteScript+0x146
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!JS_ExecuteScript+0x45
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!RunFile+0x174
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!ProcessArgs+0x1e5
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!Shell+0x195
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!main+0xec8
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!__tmainCRTStartup+0x199
+Minor       : js_dbg_32_prof_dm_windows_388bdc46ba51!mainCRTStartup+0xd
+Minor       : kernel32!BaseThreadInitThunk+0x12
+Excluded    : ntdll!RtlInitializeExceptionChain+0x63
+Excluded    : ntdll!RtlInitializeExceptionChain+0x36
+Instruction Address: 0x0000000001206fbd
+Source File: c:\users\fuzz1win\shell-cache\js-dbg-32-prof-dm-windows-388bdc46ba51\objdir-js\dist\include\js\value.h
+Source Line: 1218
+
+Description: Possible Stack Corruption
+Short Description: PossibleStackCorruption
+Exploitability Classification: UNKNOWN
+Recommended Bug Title: Possible Stack Corruption starting at js_dbg_32_prof_dm_windows_388bdc46ba51!JS::Value::isMagic+0x000000000000004d (Hash=0x815301b3.0x762bfe25)
+
+The stack trace contains one or more locations for which no symbol or module could be found. This may be a sign of stack corruption.
+0:000> .echo Backtrace of faulting thread, limited to 250 frames
+Backtrace of faulting thread, limited to 250 frames
+0:000> ~#kn 250
+ # ChildEBP RetAddr
+WARNING: Stack unwind information not available. Following frames may be wrong.
+00 0020ce50 772219fc ntdll!NtWaitForMultipleObjects+0x15
+01 0020ce98 77224200 kernel32!WaitForMultipleObjectsEx+0x8e
+02 0020ceb4 772480ec kernel32!WaitForMultipleObjects+0x18
+03 0020cf20 77247fab kernel32!GetApplicationRecoveryCallback+0x2a7
+04 0020cf34 772478a0 kernel32!GetApplicationRecoveryCallback+0x166
+05 0020cf44 7724781f kernel32!UnhandledExceptionFilter+0x161
+06 0020cfd0 779f3b8f kernel32!UnhandledExceptionFilter+0xe0
+07 0020fdbc 779b97c5 ntdll!RtlKnownExceptionFilter+0xb7
+08 0020fdd4 00000000 ntdll!RtlInitializeExceptionChain+0x36
+0:000> q
+quit:

--- a/FTB/Signatures/cdb-crash-report-example-4.txt
+++ b/FTB/Signatures/cdb-crash-report-example-4.txt
@@ -1,0 +1,147 @@
+
+Microsoft (R) Windows Debugger Version 6.12.0002.633 AMD64
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+
+Loading Dump File [c:\Users\fuzz1win\AppData\Local\CrashDumps\js-64-windows-789a12291942.exe.5268.dmp]
+User Mini Dump File: Only registers, stack and portions of memory are available
+
+Symbol search path is: *** Invalid ***
+****************************************************************************
+* Symbol loading may be unreliable without a symbol search path.           *
+* Use .symfix to have the debugger choose a symbol path.                   *
+* After setting your symbol path, use .reload to refresh symbol locations. *
+****************************************************************************
+Executable search path is:
+Windows 7 Version 7601 (Service Pack 1) MP (8 procs) Free x64
+Product: WinNt, suite: SingleUserTS
+Machine Name:
+Debug session time: Tue Mar  8 16:05:04.000 2016 (UTC - 8:00)
+System Uptime: not available
+Process Uptime: 0 days 0:00:01.000
+...........................
+This dump file has an exception of interest stored in it.
+The stored exception information can be accessed via .ecxr.
+(1494.12b0): Access violation - code c0000005 (first/second chance not available)
+*** WARNING: Unable to verify checksum for js-64-windows-789a12291942.exe
+js_64_windows_789a12291942!js::Debugger::slowPathOnLeaveFrame+0x38b:
+00000001`3f48de1b 488b4208        mov     rax,qword ptr [rdx+8] ds:e5e5e5e5`e5e5e5ed=????????????????
+0:000> cdb: Reading initial command '.load C:\Program Files\Debugging Tools for Windows (x64)\winext\msec.dll;$<c:\Users\fuzz1win\funfuzz\util\cdbCmds.txt'
+0:000> .echo Toggle for 32-bit/64-bit modes
+Toggle for 32-bit/64-bit modes
+0:000> .echo See http://people.mozilla.org/~aklotz/windbgcheatsheet.html
+See http://people.mozilla.org/~aklotz/windbgcheatsheet.html
+0:000> !wow64exts.sw
+The current thread doesn't have an x86 context.
+0:000> .echo Display lines in stack trace
+Display lines in stack trace
+0:000> .lines
+Line number information will be loaded
+0:000> .echo .ecxr switches to the exception context frame
+.ecxr switches to the exception context frame
+0:000> .ecxr
+rax=00000000002cd918 rbx=e5e5e5e5e5e5e5e5 rcx=000000000201e830
+rdx=e5e5e5e5e5e5e5e5 rsi=0000000000000002 rdi=00000000002cdaa8
+rip=000000013f48de1b rsp=00000000002cd8b0 rbp=00000000002cd9b0
+ r8=fffffffffffffff2  r9=00000000002cd718 r10=fffc000000000000
+r11=00000000002cd860 r12=0000000000000000 r13=0000000000000003
+r14=00007fffffffffff r15=fffc000000000000
+iopl=0         nv up ei pl nz na po nc
+cs=0033  ss=002b  ds=002b  es=002b  fs=0053  gs=002b             efl=00010204
+js_64_windows_789a12291942!js::Debugger::slowPathOnLeaveFrame+0x38b:
+00000001`3f48de1b 488b4208        mov     rax,qword ptr [rdx+8] ds:e5e5e5e5`e5e5e5ed=????????????????
+0:000> .echo Inspect program counter, equivalent of gdb's "x/i $pc"
+Inspect program counter, equivalent of gdb's "x/i $pc"
+0:000> u
+js_64_windows_789a12291942!js::Debugger::slowPathOnLeaveFrame+0x38b [c:\users\fuzz1win\trees\mozilla-central\js\src\vm\debugger.cpp @ 787]:
+00000001`3f48de1b 488b4208        mov     rax,qword ptr [rdx+8]
+00000001`3f48de1f 8b4810          mov     ecx,dword ptr [rax+10h]
+00000001`3f48de22 c1e91b          shr     ecx,1Bh
+00000001`3f48de25 85c9            test    ecx,ecx
+00000001`3f48de27 0f84ba000000    je      js_64_windows_789a12291942!js::Debugger::slowPathOnLeaveFrame+0x457 (00000001`3f48dee7)
+00000001`3f48de2d 4883c220        add     rdx,20h
+00000001`3f48de31 e9bb000000      jmp     js_64_windows_789a12291942!js::Debugger::slowPathOnLeaveFrame+0x461 (00000001`3f48def1)
+00000001`3f48de36 488b85f0000000  mov     rax,qword ptr [rbp+0F0h]
+0:000> .echo Inspect eip (32-bit) register, equivalent of gdb's "x/b $eax"
+Inspect eip (32-bit) register, equivalent of gdb's "x/b $eax"
+0:000> db @@c++(@eip) L4
+00000000`3f48de1b  ?? ?? ?? ??                                      ????
+0:000> .echo Inspect rip (64-bit) register, equivalent of gdb's "x/b $rax"
+Inspect rip (64-bit) register, equivalent of gdb's "x/b $rax"
+0:000> db @@c++(@rip) L8
+00000001`3f48de1b  48 8b 42 08 8b 48 10 c1                          H.B..H..
+0:000> .echo To switch frames: .frame /r /c <frame number>
+To switch frames: .frame /r /c <frame number>
+0:000> .echo Then inspect locals using: dv <locals in this frame>
+Then inspect locals using: dv <locals in this frame>
+0:000> .echo Running !exploitable
+Running !exploitable
+0:000> !exploitable -v
+
+!exploitable 1.6.0.0
+HostMachine\HostUser
+Executing Processor Architecture is x64
+Debuggee is in User Mode
+Debuggee is a user mode small dump file
+Event Type: Exception
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for ntdll.dll -
+Exception Faulting Address: 0xffffffffffffffff
+Second Chance Exception Type: STATUS_ACCESS_VIOLATION (0xC0000005)
+Exception Sub-Type: Read Access Violation
+
+Faulting Instruction:00000001`3f48de1b mov rax,qword ptr [rdx+8]
+
+Basic Block:
+    00000001`3f48de1b mov rax,qword ptr [rdx+8]
+       Tainted Input operands: 'rdx'
+    00000001`3f48de1f mov ecx,dword ptr [rax+10h]
+       Tainted Input operands: 'rax'
+    00000001`3f48de22 shr ecx,1bh
+    00000001`3f48de25 test ecx,ecx
+       Tainted Input operands: 'ecx'
+    00000001`3f48de27 je js_64_windows_789a12291942!js::debugger::slowpathonleaveframe+0x457 (00000001`3f48dee7)
+       Tainted Input operands: 'ZeroFlag'
+
+Exception Hash (Major/Minor): 0x4a4704ae.0x3dc2f499
+
+ Hash Usage : Stack Trace:
+Major+Minor : js_64_windows_789a12291942!js::Debugger::slowPathOnLeaveFrame+0x38b
+Major+Minor : js_64_windows_789a12291942!js::Debugger::onLeaveFrame+0xc3
+Major+Minor : js_64_windows_789a12291942!js::jit::HandleExceptionBaseline+0x2b4
+Major+Minor : js_64_windows_789a12291942!js::jit::HandleException+0x3ca
+Major+Minor : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Instruction Address: 0x000000013f48de1b
+Source File: c:\users\fuzz1win\trees\mozilla-central\js\src\vm\debugger.cpp
+Source Line: 787
+
+Description: Data from Faulting Address controls Branch Selection
+Short Description: TaintedDataControlsBranchSelection
+Exploitability Classification: UNKNOWN
+Recommended Bug Title: Data from Faulting Address controls Branch Selection starting at js_64_windows_789a12291942!js::Debugger::slowPathOnLeaveFrame+0x000000000000038b (Hash=0x4a4704ae.0x3dc2f499)
+
+The data from the faulting address is later used to determine whether or not a branch is taken.
+0:000> .echo Backtrace of faulting thread, limited to 250 frames
+Backtrace of faulting thread, limited to 250 frames
+0:000> ~#kn 250
+ # Child-SP          RetAddr           Call Site
+00 00000000`002cd8b0 00000001`3f565ea3 js_64_windows_789a12291942!js::Debugger::slowPathOnLeaveFrame+0x38b [c:\users\fuzz1win\trees\mozilla-central\js\src\vm\debugger.cpp @ 787]
+01 00000000`002cdb40 00000001`3f5949d4 js_64_windows_789a12291942!js::Debugger::onLeaveFrame+0xc3 [c:\users\fuzz1win\trees\mozilla-central\js\src\vm\debugger-inl.h @ 27]
+02 00000000`002cdb70 00000001`3f5943da js_64_windows_789a12291942!js::jit::HandleExceptionBaseline+0x2b4 [c:\users\fuzz1win\trees\mozilla-central\js\src\jit\jitframes.cpp @ 691]
+03 00000000`002cdc30 00000025`fecf0162 js_64_windows_789a12291942!js::jit::HandleException+0x3ca [c:\users\fuzz1win\trees\mozilla-central\js\src\jit\jitframes.cpp @ 843]
+04 00000000`002ce060 0000020e`ba240487 0x25`fecf0162
+05 00000000`002ce068 00000000`002ce148 0x20e`ba240487
+06 00000000`002ce070 00000000`02086098 0x2ce148
+07 00000000`002ce078 0000020e`ba240487 0x2086098
+08 00000000`002ce080 00000000`0678d160 0x20e`ba240487
+09 00000000`002ce088 00000000`002ce090 0x678d160
+0a 00000000`002ce090 00000000`00001844 0x2ce090
+0b 00000000`002ce098 00000000`00000000 0x1844
+0:000> q
+quit:

--- a/FTB/Signatures/cdb-crash-report-example-5.txt
+++ b/FTB/Signatures/cdb-crash-report-example-5.txt
@@ -1,0 +1,170 @@
+
+Microsoft (R) Windows Debugger Version 6.12.0002.633 AMD64
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+
+Loading Dump File [c:\Users\fuzz1win\AppData\Local\CrashDumps\js-dbg-64-windows-789a12291942.exe.6204.dmp]
+User Mini Dump File: Only registers, stack and portions of memory are available
+
+Symbol search path is: *** Invalid ***
+****************************************************************************
+* Symbol loading may be unreliable without a symbol search path.           *
+* Use .symfix to have the debugger choose a symbol path.                   *
+* After setting your symbol path, use .reload to refresh symbol locations. *
+****************************************************************************
+Executable search path is:
+Windows 7 Version 7601 (Service Pack 1) MP (8 procs) Free x64
+Product: WinNt, suite: SingleUserTS
+Machine Name:
+Debug session time: Tue Mar  8 16:18:07.000 2016 (UTC - 8:00)
+System Uptime: not available
+Process Uptime: 0 days 0:00:01.000
+...........................
+This dump file has an exception of interest stored in it.
+The stored exception information can be accessed via .ecxr.
+(183c.10f4): Access violation - code c0000005 (first/second chance not available)
+*** WARNING: Unable to verify checksum for js-dbg-64-windows-789a12291942.exe
+js_dbg_64_windows_789a12291942!js::jit::JitCode::FromExecutable+0x4:
+00000001`401bca44 488b41f8        mov     rax,qword ptr [rcx-8] ds:e5e5e5e5`e5e5e5dd=????????????????
+0:000> cdb: Reading initial command '.load C:\Program Files\Debugging Tools for Windows (x64)\winext\msec.dll;$<c:\Users\fuzz1win\funfuzz\util\cdbCmds.txt'
+0:000> .echo Toggle for 32-bit/64-bit modes
+Toggle for 32-bit/64-bit modes
+0:000> .echo See http://people.mozilla.org/~aklotz/windbgcheatsheet.html
+See http://people.mozilla.org/~aklotz/windbgcheatsheet.html
+0:000> !wow64exts.sw
+The current thread doesn't have an x86 context.
+0:000> .echo Display lines in stack trace
+Display lines in stack trace
+0:000> .lines
+Line number information will be loaded
+0:000> .echo .ecxr switches to the exception context frame
+.ecxr switches to the exception context frame
+0:000> .ecxr
+rax=0000000000000002 rbx=000000000207a020 rcx=e5e5e5e5e5e5e5e5
+rdx=000000000041af58 rsi=0000000000000000 rdi=000000000041af58
+rip=00000001401bca44 rsp=000000000041ab80 rbp=000000000041af58
+ r8=0000000003aaf000  r9=000000000041ac40 r10=0000000003a786c3
+r11=000000000000000e r12=0000000000000001 r13=0000000003aa5000
+r14=0000000002025430 r15=000000000041af58
+iopl=0         nv up ei pl nz na pe nc
+cs=0033  ss=002b  ds=002b  es=002b  fs=0053  gs=002b             efl=00010200
+js_dbg_64_windows_789a12291942!js::jit::JitCode::FromExecutable+0x4:
+00000001`401bca44 488b41f8        mov     rax,qword ptr [rcx-8] ds:e5e5e5e5`e5e5e5dd=????????????????
+0:000> .echo Inspect program counter, equivalent of gdb's "x/i $pc"
+Inspect program counter, equivalent of gdb's "x/i $pc"
+0:000> u
+js_dbg_64_windows_789a12291942!js::jit::JitCode::FromExecutable+0x4 [c:\users\fuzz1win\trees\mozilla-central\js\src\jit\ioncode.h @ 142]:
+00000001`401bca44 488b41f8        mov     rax,qword ptr [rcx-8]
+00000001`401bca48 483908          cmp     qword ptr [rax],rcx
+00000001`401bca4b 745e            je      js_dbg_64_windows_789a12291942!js::jit::JitCode::FromExecutable+0x6b (00000001`401bcaab)
+00000001`401bca4d ff151d6b9d00    call    qword ptr [js_dbg_64_windows_789a12291942!_imp___iob_func (00000001`40b93570)]
+00000001`401bca53 4c8d0d66ec7400  lea     r9,[js_dbg_64_windows_789a12291942!`string' (00000001`4090b6c0)]
+00000001`401bca5a 4c8d0507d47800  lea     r8,[js_dbg_64_windows_789a12291942!`string' (00000001`40949e68)]
+00000001`401bca61 488d15e89a6c00  lea     rdx,[js_dbg_64_windows_789a12291942!`string' (00000001`40886550)]
+00000001`401bca68 488d4860        lea     rcx,[rax+60h]
+0:000> .echo Inspect eip (32-bit) register, equivalent of gdb's "x/b $eax"
+Inspect eip (32-bit) register, equivalent of gdb's "x/b $eax"
+0:000> db @@c++(@eip) L4
+00000000`401bca44  ?? ?? ?? ??                                      ????
+0:000> .echo Inspect rip (64-bit) register, equivalent of gdb's "x/b $rax"
+Inspect rip (64-bit) register, equivalent of gdb's "x/b $rax"
+0:000> db @@c++(@rip) L8
+00000001`401bca44  48 8b 41 f8 48 39 08 74                          H.A.H9.t
+0:000> .echo To switch frames: .frame /r /c <frame number>
+To switch frames: .frame /r /c <frame number>
+0:000> .echo Then inspect locals using: dv <locals in this frame>
+Then inspect locals using: dv <locals in this frame>
+0:000> .echo Running !exploitable
+Running !exploitable
+0:000> !exploitable -v
+
+!exploitable 1.6.0.0
+HostMachine\HostUser
+Executing Processor Architecture is x64
+Debuggee is in User Mode
+Debuggee is a user mode small dump file
+Event Type: Exception
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for ntdll.dll -
+Exception Faulting Address: 0xffffffffffffffff
+Second Chance Exception Type: STATUS_ACCESS_VIOLATION (0xC0000005)
+Exception Sub-Type: Read Access Violation
+
+Faulting Instruction:00000001`401bca44 mov rax,qword ptr [rcx-8]
+
+Basic Block:
+    00000001`401bca44 mov rax,qword ptr [rcx-8]
+       Tainted Input operands: 'rcx'
+    00000001`401bca48 cmp qword ptr [rax],rcx
+       Tainted Input operands: 'rax','rcx'
+    00000001`401bca4b je js_dbg_64_windows_789a12291942!js::jit::jitcode::fromexecutable+0x6b (00000001`401bcaab)
+       Tainted Input operands: 'ZeroFlag'
+
+Exception Hash (Major/Minor): 0x7d4b9036.0x18135d04
+
+ Hash Usage : Stack Trace:
+Major+Minor : js_dbg_64_windows_789a12291942!js::jit::JitCode::FromExecutable+0x4
+Major+Minor : js_dbg_64_windows_789a12291942!js::jit::ICStub::trace+0x22
+Major+Minor : js_dbg_64_windows_789a12291942!js::jit::ICEntry::trace+0x20
+Major+Minor : js_dbg_64_windows_789a12291942!js::jit::IonScript::trace+0xb4
+Major+Minor : js_dbg_64_windows_789a12291942!js::jit::MarkIonJSFrame+0x52
+Minor       : js_dbg_64_windows_789a12291942!js::jit::MarkJitActivation+0x116
+Minor       : js_dbg_64_windows_789a12291942!js::jit::MarkJitActivations+0x50
+Minor       : js_dbg_64_windows_789a12291942!js::gc::GCRuntime::markRuntime+0x4b6
+Minor       : js_dbg_64_windows_789a12291942!js::gc::GCRuntime::updatePointersToRelocatedCells+0x1d7
+Minor       : js_dbg_64_windows_789a12291942!js::gc::GCRuntime::compactPhase+0x185
+Minor       : js_dbg_64_windows_789a12291942!js::gc::GCRuntime::incrementalCollectSlice+0x48a
+Minor       : js_dbg_64_windows_789a12291942!js::gc::GCRuntime::gcCycle+0x291
+Minor       : js_dbg_64_windows_789a12291942!js::gc::GCRuntime::collect+0x1e9
+Minor       : js_dbg_64_windows_789a12291942!js::gc::GCRuntime::runDebugGC+0xde
+Minor       : js_dbg_64_windows_789a12291942!js::gc::GCRuntime::gcIfNeededPerAllocation+0x73
+Minor       : js_dbg_64_windows_789a12291942!js::gc::GCRuntime::checkAllocatorState<1>+0x1d
+Minor       : js_dbg_64_windows_789a12291942!js::Allocate<JSObject,1>+0x1ab
+Minor       : js_dbg_64_windows_789a12291942!js::ArrayObject::createArrayInternal+0x310
+Minor       : js_dbg_64_windows_789a12291942!js::ArrayObject::createArray+0x2a
+Minor       : js_dbg_64_windows_789a12291942!NewArray<4294967295>+0x5f3
+Minor       : js_dbg_64_windows_789a12291942!NewArrayTryUseGroup<4294967295>+0x278
+Minor       : js_dbg_64_windows_789a12291942!js::NewFullyAllocatedArrayTryUseGroup+0x12
+Minor       : js_dbg_64_windows_789a12291942!js::jit::NewArrayWithGroup+0x24
+Minor       : Unknown
+Minor       : Unknown
+Instruction Address: 0x00000001401bca44
+Source File: c:\users\fuzz1win\trees\mozilla-central\js\src\jit\ioncode.h
+Source Line: 142
+
+Description: Data from Faulting Address controls Branch Selection
+Short Description: TaintedDataControlsBranchSelection
+Exploitability Classification: UNKNOWN
+Recommended Bug Title: Data from Faulting Address controls Branch Selection starting at js_dbg_64_windows_789a12291942!js::jit::JitCode::FromExecutable+0x0000000000000004 (Hash=0x7d4b9036.0x18135d04)
+
+The data from the faulting address is later used to determine whether or not a branch is taken.
+0:000> .echo Backtrace of faulting thread, limited to 250 frames
+Backtrace of faulting thread, limited to 250 frames
+0:000> ~#kn 250
+ # Child-SP          RetAddr           Call Site
+00 00000000`0041ab80 00000001`4053eca2 js_dbg_64_windows_789a12291942!js::jit::JitCode::FromExecutable+0x4 [c:\users\fuzz1win\trees\mozilla-central\js\src\jit\ioncode.h @ 142]
+01 00000000`0041abc0 00000001`4053ec60 js_dbg_64_windows_789a12291942!js::jit::ICStub::trace+0x22 [c:\users\fuzz1win\trees\mozilla-central\js\src\jit\sharedic.cpp @ 164]
+02 00000000`0041ac00 00000001`401f6034 js_dbg_64_windows_789a12291942!js::jit::ICEntry::trace+0x20 [c:\users\fuzz1win\trees\mozilla-central\js\src\jit\sharedic.cpp @ 100]
+03 00000000`0041ac30 00000001`400af592 js_dbg_64_windows_789a12291942!js::jit::IonScript::trace+0xb4 [c:\users\fuzz1win\trees\mozilla-central\js\src\jit\ion.cpp @ 1068]
+04 00000000`0041ac70 00000001`400afa66 js_dbg_64_windows_789a12291942!js::jit::MarkIonJSFrame+0x52 [c:\users\fuzz1win\trees\mozilla-central\js\src\jit\jitframes.cpp @ 1025]
+05 00000000`0041ad60 00000001`400afbc0 js_dbg_64_windows_789a12291942!js::jit::MarkJitActivation+0x116 [c:\users\fuzz1win\trees\mozilla-central\js\src\jit\jitframes.cpp @ 1423]
+06 00000000`0041add0 00000001`40035f96 js_dbg_64_windows_789a12291942!js::jit::MarkJitActivations+0x50 [c:\users\fuzz1win\trees\mozilla-central\js\src\jit\jitframes.cpp @ 1446]
+07 00000000`0041ae10 00000001`3fc0d067 js_dbg_64_windows_789a12291942!js::gc::GCRuntime::markRuntime+0x4b6 [c:\users\fuzz1win\trees\mozilla-central\js\src\gc\rootmarking.cpp @ 326]
+08 00000000`0041aef0 00000001`3fbda765 js_dbg_64_windows_789a12291942!js::gc::GCRuntime::updatePointersToRelocatedCells+0x1d7 [c:\users\fuzz1win\trees\mozilla-central\js\src\jsgc.cpp @ 2795]
+09 00000000`0041afb0 00000001`3fbf162a js_dbg_64_windows_789a12291942!js::gc::GCRuntime::compactPhase+0x185 [c:\users\fuzz1win\trees\mozilla-central\js\src\jsgc.cpp @ 5761]
+0a 00000000`0041b010 00000001`3fbeb071 js_dbg_64_windows_789a12291942!js::gc::GCRuntime::incrementalCollectSlice+0x48a [c:\users\fuzz1win\trees\mozilla-central\js\src\jsgc.cpp @ 6220]
+0b 00000000`0041b080 00000001`3fbda289 js_dbg_64_windows_789a12291942!js::gc::GCRuntime::gcCycle+0x291 [c:\users\fuzz1win\trees\mozilla-central\js\src\jsgc.cpp @ 6398]
+0c 00000000`0041b120 00000001`3fc04d6e js_dbg_64_windows_789a12291942!js::gc::GCRuntime::collect+0x1e9 [c:\users\fuzz1win\trees\mozilla-central\js\src\jsgc.cpp @ 6504]
+0d 00000000`0041b250 00000001`3fc26653 js_dbg_64_windows_789a12291942!js::gc::GCRuntime::runDebugGC+0xde [c:\users\fuzz1win\trees\mozilla-central\js\src\jsgc.cpp @ 7050]
+0e 00000000`0041b2a0 00000001`3fc13d2d js_dbg_64_windows_789a12291942!js::gc::GCRuntime::gcIfNeededPerAllocation+0x73 [c:\users\fuzz1win\trees\mozilla-central\js\src\gc\allocator.cpp @ 33]
+0f 00000000`0041b2f0 00000001`3fc0f4eb js_dbg_64_windows_789a12291942!js::gc::GCRuntime::checkAllocatorState<1>+0x1d [c:\users\fuzz1win\trees\mozilla-central\js\src\gc\allocator.cpp @ 55]
+10 00000000`0041b330 00000001`3f914a90 js_dbg_64_windows_789a12291942!js::Allocate<JSObject,1>+0x1ab [c:\users\fuzz1win\trees\mozilla-central\js\src\gc\allocator.cpp @ 121]
+11 00000000`0041b390 00000001`3f91470a js_dbg_64_windows_789a12291942!js::ArrayObject::createArrayInternal+0x310 [c:\users\fuzz1win\trees\mozilla-central\js\src\vm\arrayobject-inl.h @ 54]
+12 00000000`0041b3d0 00000001`3f8fd003 js_dbg_64_windows_789a12291942!js::ArrayObject::createArray+0x2a [c:\users\fuzz1win\trees\mozilla-central\js\src\vm\arrayobject-inl.h @ 82]
+13 00000000`0041b410 00000001`3f8fdc08 js_dbg_64_windows_789a12291942!NewArray<4294967295>+0x5f3 [c:\users\fuzz1win\trees\mozilla-central\js\src\jsarray.cpp @ 3391]
+14 00000000`0041b610 00000001`3f90e0f2 js_dbg_64_windows_789a12291942!NewArrayTryUseGroup<4294967295>+0x278 [c:\users\fuzz1win\trees\mozilla-central\js\src\jsarray.cpp @ 3532]
+15 00000000`0041b690 00000001`4030b0e4 js_dbg_64_windows_789a12291942!js::NewFullyAllocatedArrayTryUseGroup+0x12 [c:\users\fuzz1win\trees\mozilla-central\js\src\jsarray.cpp @ 3554]
+16 00000000`0041b6d0 0000035c`9168982b js_dbg_64_windows_789a12291942!js::jit::NewArrayWithGroup+0x24 [c:\users\fuzz1win\trees\mozilla-central\js\src\jit\codegenerator.cpp @ 4741]
+17 00000000`0041b710 fffc0000`03784700 0x35c`9168982b
+18 00000000`0041b718 00000000`00000000 0xfffc0000`03784700
+0:000> q
+quit:

--- a/FTB/Signatures/cdb-crash-report-example-6.txt
+++ b/FTB/Signatures/cdb-crash-report-example-6.txt
@@ -1,0 +1,186 @@
+
+Microsoft (R) Windows Debugger Version 6.12.0002.633 AMD64
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+
+Loading Dump File [c:\Users\fuzz1win\AppData\Local\CrashDumps\js-dbg-64-windows-789a12291942.exe.6424.dmp]
+User Mini Dump File: Only registers, stack and portions of memory are available
+
+Symbol search path is: *** Invalid ***
+****************************************************************************
+* Symbol loading may be unreliable without a symbol search path.           *
+* Use .symfix to have the debugger choose a symbol path.                   *
+* After setting your symbol path, use .reload to refresh symbol locations. *
+****************************************************************************
+Executable search path is:
+Windows 7 Version 7601 (Service Pack 1) MP (8 procs) Free x64
+Product: WinNt, suite: SingleUserTS
+Machine Name:
+Debug session time: Tue Mar  8 16:21:29.000 2016 (UTC - 8:00)
+System Uptime: not available
+Process Uptime: not available
+...........................
+This dump file has an exception of interest stored in it.
+The stored exception information can be accessed via .ecxr.
+(1918.19bc): Access violation - code c0000005 (first/second chance not available)
+*** WARNING: Unable to verify checksum for js-dbg-64-windows-789a12291942.exe
+js_dbg_64_windows_789a12291942!js::ExpandErrorArgumentsVA+0x203:
+00000001`3f523043 803c0200        cmp     byte ptr [rdx+rax],0 ds:00000000`00000000=??
+0:000> cdb: Reading initial command '.load C:\Program Files\Debugging Tools for Windows (x64)\winext\msec.dll;$<c:\Users\fuzz1win\funfuzz\util\cdbCmds.txt'
+0:000> .echo Toggle for 32-bit/64-bit modes
+Toggle for 32-bit/64-bit modes
+0:000> .echo See http://people.mozilla.org/~aklotz/windbgcheatsheet.html
+See http://people.mozilla.org/~aklotz/windbgcheatsheet.html
+0:000> !wow64exts.sw
+The current thread doesn't have an x86 context.
+0:000> .echo Display lines in stack trace
+Display lines in stack trace
+0:000> .lines
+Line number information will be loaded
+0:000> .echo .ecxr switches to the exception context frame
+.ecxr switches to the exception context frame
+0:000> .ecxr
+rax=0000000000000000 rbx=0000000000000000 rcx=0000000003cae900
+rdx=0000000000000000 rsi=00000000002ab380 rdi=ffffffffffffffff
+rip=000000013f523043 rsp=00000000002ab190 rbp=00000000002ab290
+ r8=0000000001cc29f7  r9=00000000ffffffc0 r10=0000000003cae000
+r11=0000000003cae900 r12=0000000000000002 r13=0000000000000000
+r14=00000000002ab4a8 r15=0000000000000000
+iopl=0         nv up ei pl zr ac po nc
+cs=0033  ss=002b  ds=002b  es=002b  fs=0053  gs=002b             efl=00010254
+js_dbg_64_windows_789a12291942!js::ExpandErrorArgumentsVA+0x203:
+00000001`3f523043 803c0200        cmp     byte ptr [rdx+rax],0 ds:00000000`00000000=??
+0:000> .echo Inspect program counter, equivalent of gdb's "x/i $pc"
+Inspect program counter, equivalent of gdb's "x/i $pc"
+0:000> u
+js_dbg_64_windows_789a12291942!js::ExpandErrorArgumentsVA+0x203 [c:\users\fuzz1win\trees\mozilla-central\js\src\jscntxt.cpp @ 608]:
+00000001`3f523043 803c0200        cmp     byte ptr [rdx+rax],0
+00000001`3f523047 75f7            jne     js_dbg_64_windows_789a12291942!js::ExpandErrorArgumentsVA+0x200 (00000001`3f523040)
+00000001`3f523049 488b4c2450      mov     rcx,qword ptr [rsp+50h]
+00000001`3f52304e 4889442468      mov     qword ptr [rsp+68h],rax
+00000001`3f523053 410fb7c7        movzx   eax,r15w
+00000001`3f523057 4c8d442468      lea     r8,[rsp+68h]
+00000001`3f52305c 488d1cc500000000 lea     rbx,[rax*8]
+00000001`3f523064 e8070e4100      call    js_dbg_64_windows_789a12291942!js::InflateString (00000001`3f933e70)
+0:000> .echo Inspect eip (32-bit) register, equivalent of gdb's "x/b $eax"
+Inspect eip (32-bit) register, equivalent of gdb's "x/b $eax"
+0:000> db @@c++(@eip) L4
+00000000`3f523043  ?? ?? ?? ??                                      ????
+0:000> .echo Inspect rip (64-bit) register, equivalent of gdb's "x/b $rax"
+Inspect rip (64-bit) register, equivalent of gdb's "x/b $rax"
+0:000> db @@c++(@rip) L8
+00000001`3f523043  80 3c 02 00 75 f7 48 8b                          .<..u.H.
+0:000> .echo To switch frames: .frame /r /c <frame number>
+To switch frames: .frame /r /c <frame number>
+0:000> .echo Then inspect locals using: dv <locals in this frame>
+Then inspect locals using: dv <locals in this frame>
+0:000> .echo Running !exploitable
+Running !exploitable
+0:000> !exploitable -v
+
+!exploitable 1.6.0.0
+HostMachine\HostUser
+Executing Processor Architecture is x64
+Debuggee is in User Mode
+Debuggee is a user mode small dump file
+Event Type: Exception
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for ntdll.dll -
+Exception Faulting Address: 0x0
+Second Chance Exception Type: STATUS_ACCESS_VIOLATION (0xC0000005)
+Exception Sub-Type: Read Access Violation
+
+Faulting Instruction:00000001`3f523043 cmp byte ptr [rdx+rax],0
+
+Basic Block:
+    00000001`3f523043 cmp byte ptr [rdx+rax],0
+       Tainted Input operands: 'rax','rdx'
+    00000001`3f523047 jne js_dbg_64_windows_789a12291942!js::expanderrorargumentsva+0x200 (00000001`3f523040)
+       Tainted Input operands: 'ZeroFlag'
+
+Exception Hash (Major/Minor): 0x8487b3c3.0x009f5150
+
+ Hash Usage : Stack Trace:
+Major+Minor : js_dbg_64_windows_789a12291942!js::ExpandErrorArgumentsVA+0x203
+Major+Minor : js_dbg_64_windows_789a12291942!js::ReportErrorNumberVA+0xd5
+Major+Minor : js_dbg_64_windows_789a12291942!JS_ReportErrorFlagsAndNumber+0x4d
+Major+Minor : js_dbg_64_windows_789a12291942!js::EnterDebuggeeNoExecute::reportIfFoundInStack+0x117
+Major+Minor : js_dbg_64_windows_789a12291942!js::Debugger::slowPathCheckNoExecute+0xf1
+Minor       : js_dbg_64_windows_789a12291942!js::Debugger::checkNoExecute+0x35
+Minor       : js_dbg_64_windows_789a12291942!js::RunScript+0x7b
+Minor       : js_dbg_64_windows_789a12291942!js::Invoke+0x49e
+Minor       : js_dbg_64_windows_789a12291942!js::Invoke+0x1c2
+Minor       : js_dbg_64_windows_789a12291942!js::DirectProxyHandler::call+0x9d
+Minor       : js_dbg_64_windows_789a12291942!js::CrossCompartmentWrapper::call+0x120
+Minor       : js_dbg_64_windows_789a12291942!js::Proxy::call+0x1c7
+Minor       : js_dbg_64_windows_789a12291942!js::proxy_Call+0xff
+Minor       : js_dbg_64_windows_789a12291942!js::CallJSNative+0x79
+Minor       : js_dbg_64_windows_789a12291942!js::Invoke+0x40e
+Minor       : js_dbg_64_windows_789a12291942!js::Invoke+0x1c2
+Minor       : js_dbg_64_windows_789a12291942!js::jit::DoCallFallback+0x14bb
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : js_dbg_64_windows_789a12291942!DoCallFallbackInfo+0x0
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Minor       : Unknown
+Instruction Address: 0x000000013f523043
+Source File: c:\users\fuzz1win\trees\mozilla-central\js\src\jscntxt.cpp
+Source Line: 608
+
+Description: Read Access Violation near NULL
+Short Description: ReadAVNearNull
+Exploitability Classification: PROBABLY_NOT_EXPLOITABLE
+Recommended Bug Title: Read Access Violation near NULL starting at js_dbg_64_windows_789a12291942!js::ExpandErrorArgumentsVA+0x0000000000000203 (Hash=0x8487b3c3.0x009f5150)
+
+This is a user mode read access violation near null, and is probably not exploitable.
+0:000> .echo Backtrace of faulting thread, limited to 250 frames
+Backtrace of faulting thread, limited to 250 frames
+0:000> ~#kn 250
+ # Child-SP          RetAddr           Call Site
+00 00000000`002ab190 00000001`3f53b4f5 js_dbg_64_windows_789a12291942!js::ExpandErrorArgumentsVA+0x203 [c:\users\fuzz1win\trees\mozilla-central\js\src\jscntxt.cpp @ 608]
+01 00000000`002ab330 00000001`3f5352ad js_dbg_64_windows_789a12291942!js::ReportErrorNumberVA+0xd5 [c:\users\fuzz1win\trees\mozilla-central\js\src\jscntxt.cpp @ 744]
+02 00000000`002ab410 00000001`3f79a987 js_dbg_64_windows_789a12291942!JS_ReportErrorFlagsAndNumber+0x4d [c:\users\fuzz1win\trees\mozilla-central\js\src\jsapi.cpp @ 5375]
+03 00000000`002ab480 00000001`3f79f0b1 js_dbg_64_windows_789a12291942!js::EnterDebuggeeNoExecute::reportIfFoundInStack+0x117 [c:\users\fuzz1win\trees\mozilla-central\js\src\vm\debugger.cpp @ 359]
+04 00000000`002ab500 00000001`3fa3c6a5 js_dbg_64_windows_789a12291942!js::Debugger::slowPathCheckNoExecute+0xf1 [c:\users\fuzz1win\trees\mozilla-central\js\src\vm\debugger.cpp @ 400]
+05 00000000`002ab540 00000001`3fa31bbb js_dbg_64_windows_789a12291942!js::Debugger::checkNoExecute+0x35 [c:\users\fuzz1win\trees\mozilla-central\js\src\vm\debugger-inl.h @ 42]
+06 00000000`002ab570 00000001`3fa284ce js_dbg_64_windows_789a12291942!js::RunScript+0x7b [c:\users\fuzz1win\trees\mozilla-central\js\src\vm\interpreter.cpp @ 392]
+07 00000000`002ab6a0 00000001`3fa28742 js_dbg_64_windows_789a12291942!js::Invoke+0x49e [c:\users\fuzz1win\trees\mozilla-central\js\src\vm\interpreter.cpp @ 496]
+08 00000000`002ab730 00000001`3f9881ed js_dbg_64_windows_789a12291942!js::Invoke+0x1c2 [c:\users\fuzz1win\trees\mozilla-central\js\src\vm\interpreter.cpp @ 530]
+09 00000000`002ab860 00000001`3f987ff0 js_dbg_64_windows_789a12291942!js::DirectProxyHandler::call+0x9d [c:\users\fuzz1win\trees\mozilla-central\js\src\proxy\directproxyhandler.cpp @ 77]
+0a 00000000`002ab8c0 00000001`3f988517 js_dbg_64_windows_789a12291942!js::CrossCompartmentWrapper::call+0x120 [c:\users\fuzz1win\trees\mozilla-central\js\src\proxy\crosscompartmentwrapper.cpp @ 289]
+0b 00000000`002ab960 00000001`3f990f1f js_dbg_64_windows_789a12291942!js::Proxy::call+0x1c7 [c:\users\fuzz1win\trees\mozilla-central\js\src\proxy\proxy.cpp @ 391]
+0c 00000000`002aba40 00000001`3fa0c609 js_dbg_64_windows_789a12291942!js::proxy_Call+0xff [c:\users\fuzz1win\trees\mozilla-central\js\src\proxy\proxy.cpp @ 683]
+0d 00000000`002abab0 00000001`3fa2843e js_dbg_64_windows_789a12291942!js::CallJSNative+0x79 [c:\users\fuzz1win\trees\mozilla-central\js\src\jscntxtinlines.h @ 235]
+0e 00000000`002abb00 00000001`3fa28742 js_dbg_64_windows_789a12291942!js::Invoke+0x40e [c:\users\fuzz1win\trees\mozilla-central\js\src\vm\interpreter.cpp @ 478]
+0f 00000000`002abb90 00000001`3feb1bcb js_dbg_64_windows_789a12291942!js::Invoke+0x1c2 [c:\users\fuzz1win\trees\mozilla-central\js\src\vm\interpreter.cpp @ 530]
+10 00000000`002abcc0 00000042`c7782828 js_dbg_64_windows_789a12291942!js::jit::DoCallFallback+0x14bb [c:\users\fuzz1win\trees\mozilla-central\js\src\jit\baselineic.cpp @ 6136]
+11 00000000`002abff0 00000000`002abe38 0x42`c7782828
+12 00000000`002abff8 00000000`002ac070 0x2abe38
+13 00000000`002ac000 fffc0000`00000000 0x2ac070
+14 00000000`002ac008 00000000`002ac9a0 0xfffc0000`00000000
+15 00000000`002ac010 00000000`002ac080 0x2ac9a0
+16 00000000`002ac018 00000000`002ac038 0x2ac080
+17 00000000`002ac020 00000000`0229a208 0x2ac038
+18 00000000`002ac028 00000000`002ac038 0x229a208
+19 00000000`002ac030 00000000`002ac108 0x2ac038
+1a 00000000`002ac038 fff90000`00000000 0x2ac108
+1b 00000000`002ac040 00000001`40516fe0 0xfff90000`00000000
+1c 00000000`002ac048 00000000`0395e700 js_dbg_64_windows_789a12291942!DoCallFallbackInfo
+1d 00000000`002ac050 00000042`c778db53 0x395e700
+1e 00000000`002ac058 00000000`00004022 0x42`c778db53
+1f 00000000`002ac060 00000000`002ac0d8 0x4022
+20 00000000`002ac068 00000000`0229a280 0x2ac0d8
+21 00000000`002ac070 00000000`00000000 0x229a280
+0:000> q
+quit:

--- a/FTB/Signatures/cdb-crash-report-example-7.txt
+++ b/FTB/Signatures/cdb-crash-report-example-7.txt
@@ -1,0 +1,197 @@
+
+Microsoft (R) Windows Debugger Version 6.3.9600.17298 X86
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+
+Loading Dump File [c:\Users\fuzz1win\AppData\Local\CrashDumps\js-dbg-32-dm-windows-918df3a0bc1c.exe.3472.dmp]
+User Mini Dump File: Only registers, stack and portions of memory are available
+
+Symbol search path is: *** Invalid ***
+****************************************************************************
+* Symbol loading may be unreliable without a symbol search path.           *
+* Use .symfix to have the debugger choose a symbol path.                   *
+* After setting your symbol path, use .reload to refresh symbol locations. *
+****************************************************************************
+Executable search path is:
+Windows 7 Version 7601 (Service Pack 1) MP (8 procs) Free x86 compatible
+Product: WinNt, suite: SingleUserTS
+Machine Name:
+Debug session time: Tue Mar  8 16:26:44.000 2016 (UTC - 8:00)
+System Uptime: not available
+Process Uptime: 0 days 0:00:01.000
+............................
+This dump file has an exception of interest stored in it.
+The stored exception information can be accessed via .ecxr.
+(d90.117c): Access violation - code c0000005 (first/second chance not available)
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for ntdll.dll -
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for kernel32.dll -
+eax=00000000 ebx=0116d234 ecx=00000000 edx=00000000 esi=00000002 edi=00000000
+eip=779c016d esp=0116d1e4 ebp=0116d280 iopl=0         nv up ei pl zr na pe nc
+cs=0023  ss=002b  ds=002b  es=002b  fs=0053  gs=002b             efl=00000246
+ntdll!NtWaitForMultipleObjects+0x15:
+779c016d 83c404          add     esp,4
+0:000> cdb: Reading initial command '.load C:\Program Files (x86)\Windows Kits\8.1\Debuggers\x86\winext\msec.dll;$<c:\Users\fuzz1win\funfuzz\util\cdbCmds.txt'
+0:000> .echo Toggle for 32-bit/64-bit modes
+Toggle for 32-bit/64-bit modes
+0:000> .echo See http://people.mozilla.org/~aklotz/windbgcheatsheet.html
+See http://people.mozilla.org/~aklotz/windbgcheatsheet.html
+0:000> !wow64exts.sw
+!wow64exts.sw : command invalid on non-64bit target
+0:000> .echo Display lines in stack trace
+Display lines in stack trace
+0:000> .lines
+Line number information will be loaded
+0:000> .echo .ecxr switches to the exception context frame
+.ecxr switches to the exception context frame
+0:000> .ecxr
+*** WARNING: Unable to verify checksum for js-dbg-32-dm-windows-918df3a0bc1c.exe
+eax=00000001 ebx=0116daa8 ecx=00000000 edx=00000000 esi=00000000 edi=0116db2c
+eip=001507e0 esp=0116d9e4 ebp=0116da70 iopl=0         nv up ei pl zr na pe nc
+cs=0023  ss=002b  ds=002b  es=002b  fs=0053  gs=002b             efl=00010246
+js_dbg_32_dm_windows_918df3a0bc1c!js::ExpandErrorArgumentsVA+0x190:
+001507e0 8a01            mov     al,byte ptr [ecx]          ds:002b:00000000=??
+0:000> .echo Inspect program counter, equivalent of gdb's "x/i $pc"
+Inspect program counter, equivalent of gdb's "x/i $pc"
+0:000> u
+js_dbg_32_dm_windows_918df3a0bc1c!js::ExpandErrorArgumentsVA+0x190 [c:\users\fuzz1win\trees\mozilla-central\js\src\jscntxt.cpp @ 608]:
+001507e0 8a01            mov     al,byte ptr [ecx]
+001507e2 41              inc     ecx
+001507e3 84c0            test    al,al
+001507e5 75f9            jne     js_dbg_32_dm_windows_918df3a0bc1c!js::ExpandErrorArgumentsVA+0x190 (001507e0)
+001507e7 2b4db0          sub     ecx,dword ptr [ebp-50h]
+001507ea 8d45a8          lea     eax,[ebp-58h]
+001507ed 50              push    eax
+001507ee 52              push    edx
+0:000> .echo Inspect eip (32-bit) register, equivalent of gdb's "x/b $eax"
+Inspect eip (32-bit) register, equivalent of gdb's "x/b $eax"
+0:000> db @@c++(@eip) L4
+001507e0  8a 01 41 84                                      ..A.
+0:000> .echo Inspect rip (64-bit) register, equivalent of gdb's "x/b $rax"
+Inspect rip (64-bit) register, equivalent of gdb's "x/b $rax"
+0:000> db @@c++(@rip) L8
+Bad register error at '@rip) '
+0:000> .echo To switch frames: .frame /r /c <frame number>
+To switch frames: .frame /r /c <frame number>
+0:000> .echo Then inspect locals using: dv <locals in this frame>
+Then inspect locals using: dv <locals in this frame>
+0:000> .echo Running !exploitable
+Running !exploitable
+0:000> !exploitable -v
+
+!exploitable 1.6.0.0
+HostMachine\HostUser
+Executing Processor Architecture is x86
+Debuggee is in User Mode
+Debuggee is a user mode small dump file
+Event Type: Exception
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for kernel32.dll -
+*** ERROR: Symbol file could not be found.  Defaulted to export symbols for ntdll.dll -
+Exception Faulting Address: 0x0
+Second Chance Exception Type: STATUS_ACCESS_VIOLATION (0xC0000005)
+Exception Sub-Type: Read Access Violation
+
+Faulting Instruction:001507e0 mov al,byte ptr [ecx]
+
+Basic Block:
+    001507e0 mov al,byte ptr [ecx]
+       Tainted Input operands: 'ecx'
+    001507e2 inc ecx
+       Tainted Input operands: 'ecx'
+    001507e3 test al,al
+       Tainted Input operands: 'al'
+    001507e5 jne js_dbg_32_dm_windows_918df3a0bc1c!js::expanderrorargumentsva+0x190 (001507e0)
+       Tainted Input operands: 'ZeroFlag'
+
+Exception Hash (Major/Minor): 0x0696b451.0xd40b252e
+
+ Hash Usage : Stack Trace:
+Major+Minor : js_dbg_32_dm_windows_918df3a0bc1c!js::ExpandErrorArgumentsVA+0x190
+Major+Minor : js_dbg_32_dm_windows_918df3a0bc1c!js::ReportErrorNumberVA+0xb4
+Major+Minor : js_dbg_32_dm_windows_918df3a0bc1c!JS_ReportErrorFlagsAndNumber+0x26
+Major+Minor : js_dbg_32_dm_windows_918df3a0bc1c!js::EnterDebuggeeNoExecute::reportIfFoundInStack+0xdd
+Major+Minor : js_dbg_32_dm_windows_918df3a0bc1c!js::Debugger::slowPathCheckNoExecute+0xc9
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Debugger::checkNoExecute+0x2b
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::RunScript+0x5d
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Invoke+0x397
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Invoke+0x1ad
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::DirectProxyHandler::call+0x78
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::CrossCompartmentWrapper::call+0xe2
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Proxy::call+0xb1
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::proxy_Call+0xbf
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::CallJSNative+0x7a
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Invoke+0x27d
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Invoke+0x1ad
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::jit::DoCallFallback+0x6a3
+Minor       : Unknown
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Activation::Activation+0x11f
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!EnterIon+0x237
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::jit::IonCannon+0x11e
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::RunScript+0x152
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Invoke+0x397
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Invoke+0x1ad
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Debugger::fireDebuggerStatement+0x27f
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Debugger::dispatchHook<<lambda_faa7d822d953ceadb53a177c78b21b2f>,<lambda_5e4e7fe14754335b+0x372
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Debugger::slowPathOnDebuggerStatement+0x4a
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::jit::OnDebuggerStatement+0x39
+Minor       : Unknown
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!EnterBaseline+0x2e4
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::jit::EnterBaselineMethod+0x11e
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::RunScript+0x204
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::ExecuteKernel+0x26d
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!EvalKernel+0x745
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::IndirectEval+0x90
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::CallJSNative+0x7a
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Invoke+0x33a
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Invoke+0x1ad
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::DirectProxyHandler::call+0x78
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::CrossCompartmentWrapper::call+0xe2
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Proxy::call+0xb1
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::proxy_Call+0xbf
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::CallJSNative+0x7a
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Invoke+0x27d
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Invoke+0x1ad
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::jit::DoCallFallback+0x6a3
+Minor       : Unknown
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!EnterIon+0x237
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::jit::IonCannon+0x11e
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::RunScript+0x152
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::ExecuteKernel+0x26d
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!js::Execute+0x1bb
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!ExecuteScript+0x146
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!JS_ExecuteScript+0x4c
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!RunFile+0x178
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!Process+0xbd
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!ProcessArgs+0x398
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!Shell+0x1ac
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!main+0xe1e
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!__tmainCRTStartup+0x199
+Minor       : js_dbg_32_dm_windows_918df3a0bc1c!mainCRTStartup+0xd
+Minor       : kernel32!BaseThreadInitThunk+0x12
+Excluded    : ntdll!RtlInitializeExceptionChain+0x63
+Excluded    : ntdll!RtlInitializeExceptionChain+0x36
+Instruction Address: 0x00000000001507e0
+Source File: c:\users\fuzz1win\trees\mozilla-central\js\src\jscntxt.cpp
+Source Line: 608
+
+Description: Read Access Violation near NULL
+Short Description: ReadAVNearNull
+Exploitability Classification: PROBABLY_NOT_EXPLOITABLE
+Recommended Bug Title: Read Access Violation near NULL starting at js_dbg_32_dm_windows_918df3a0bc1c!js::ExpandErrorArgumentsVA+0x0000000000000190 (Hash=0x0696b451.0xd40b252e)
+
+This is a user mode read access violation near null, and is probably not exploitable.
+0:000> .echo Backtrace of faulting thread, limited to 250 frames
+Backtrace of faulting thread, limited to 250 frames
+0:000> ~#kn 250
+ # ChildEBP RetAddr
+WARNING: Stack unwind information not available. Following frames may be wrong.
+00 0116d280 76e81a08 ntdll!NtWaitForMultipleObjects+0x15
+01 0116d2c8 76e84200 kernel32!WaitForMultipleObjectsEx+0x8e
+02 0116d2e4 76ea80ec kernel32!WaitForMultipleObjects+0x18
+03 0116d350 76ea7fab kernel32!GetApplicationRecoveryCallback+0x2a7
+04 0116d364 76ea78a0 kernel32!GetApplicationRecoveryCallback+0x166
+05 0116d374 76ea781f kernel32!UnhandledExceptionFilter+0x161
+06 0116d400 77a15b67 kernel32!UnhandledExceptionFilter+0xe0
+07 0116fe40 779d98d5 ntdll!RtlKnownExceptionFilter+0xb7
+08 0116fe58 00000000 ntdll!RtlInitializeExceptionChain+0x36
+0:000> q
+quit:

--- a/FTB/Signatures/tests.py
+++ b/FTB/Signatures/tests.py
@@ -892,6 +892,311 @@ class CDBSelectorTest3(unittest.TestCase):
         crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
         self.assertEqual(crashInfo.crashAddress, long(0x1206fbd))
 
+# Test 4 is an example with 64-bit js opt shell crashing with:
+#     Exception Faulting Address: 0xffffffffffffffff
+#     Second Chance Exception Type: STATUS_ACCESS_VIOLATION (0xC0000005)
+#     Faulting Instruction:00000001`3f48de1b mov rax,qword ptr [rdx+8]
+#     Exploitability Classification: UNKNOWN
+class CDBParserTestCrash4(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86-64", "windows")
+
+        with open('cdb-crash-report-example-4.txt', 'r') as f:
+            crashInfo = CDBCrashInfo([], [], config, f.read().splitlines())
+
+        self.assertEqual(len(crashInfo.backtrace), 12)
+        self.assertEqual(crashInfo.backtrace[0], "js::Debugger::slowPathOnLeaveFrame")
+        self.assertEqual(crashInfo.backtrace[1], "js::Debugger::onLeaveFrame")
+        self.assertEqual(crashInfo.backtrace[2], "js::jit::HandleExceptionBaseline")
+        self.assertEqual(crashInfo.backtrace[3], "js::jit::HandleException")
+        self.assertEqual(crashInfo.backtrace[4], "??")
+        self.assertEqual(crashInfo.backtrace[5], "??")
+        self.assertEqual(crashInfo.backtrace[6], "??")
+        self.assertEqual(crashInfo.backtrace[7], "??")
+        self.assertEqual(crashInfo.backtrace[8], "??")
+        self.assertEqual(crashInfo.backtrace[9], "??")
+        self.assertEqual(crashInfo.backtrace[10], "??")
+        self.assertEqual(crashInfo.backtrace[11], "??")
+
+        self.assertEqual(crashInfo.crashInstruction, "mov rax,qword ptr [rdx+8]")
+        self.assertEqual(crashInfo.registers["rax"], long(0x00000000002cd918))
+        self.assertEqual(crashInfo.registers["rbx"], long(0xe5e5e5e5e5e5e5e5))
+        self.assertEqual(crashInfo.registers["rcx"], long(0x000000000201e830))
+        self.assertEqual(crashInfo.registers["rdx"], long(0xe5e5e5e5e5e5e5e5))
+        self.assertEqual(crashInfo.registers["rsi"], long(0x0000000000000002))
+        self.assertEqual(crashInfo.registers["rdi"], long(0x00000000002cdaa8))
+        self.assertEqual(crashInfo.registers["rip"], long(0x000000013f48de1b))
+        self.assertEqual(crashInfo.registers["rsp"], long(0x00000000002cd8b0))
+        self.assertEqual(crashInfo.registers["rbp"], long(0x00000000002cd9b0))
+        self.assertEqual(crashInfo.registers["r8"], long(0xfffffffffffffff2))
+        self.assertEqual(crashInfo.registers["r9"], long(0x00000000002cd718))
+        self.assertEqual(crashInfo.registers["r10"], long(0xfffc000000000000))
+        self.assertEqual(crashInfo.registers["r11"], long(0x00000000002cd860))
+        self.assertEqual(crashInfo.registers["r12"], long(0x0000000000000000))
+        self.assertEqual(crashInfo.registers["r13"], long(0x0000000000000003))
+        self.assertEqual(crashInfo.registers["r14"], long(0x00007fffffffffff))
+        self.assertEqual(crashInfo.registers["r15"], long(0xfffc000000000000))
+
+        self.assertEqual(crashInfo.crashAddress, long(0xffffffffffffffff))
+
+class CDBSelectorTest4(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86-64", "windows")
+
+        with open('cdb-crash-report-example-4.txt', 'r') as f:
+            crashData = f.read().splitlines()
+
+        crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
+        self.assertEqual(crashInfo.crashAddress, long(0xffffffffffffffff))
+
+# Test 5 is an example with 64-bit js debug shell crashing with:
+#     Exception Faulting Address: 0xffffffffffffffff
+#     Second Chance Exception Type: STATUS_ACCESS_VIOLATION (0xC0000005)
+#     Faulting Instruction:00000001`401bca44 mov rax,qword ptr [rcx-8]
+#     Exploitability Classification: UNKNOWN
+class CDBParserTestCrash5(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86-64", "windows")
+
+        with open('cdb-crash-report-example-5.txt', 'r') as f:
+            crashInfo = CDBCrashInfo([], [], config, f.read().splitlines())
+
+        self.assertEqual(len(crashInfo.backtrace), 25)
+        self.assertEqual(crashInfo.backtrace[0], "js::jit::JitCode::FromExecutable")
+        self.assertEqual(crashInfo.backtrace[1], "js::jit::ICStub::trace")
+        self.assertEqual(crashInfo.backtrace[2], "js::jit::ICEntry::trace")
+        self.assertEqual(crashInfo.backtrace[3], "js::jit::IonScript::trace")
+        self.assertEqual(crashInfo.backtrace[4], "js::jit::MarkIonJSFrame")
+        self.assertEqual(crashInfo.backtrace[5], "js::jit::MarkJitActivation")
+        self.assertEqual(crashInfo.backtrace[6], "js::jit::MarkJitActivations")
+        self.assertEqual(crashInfo.backtrace[7], "js::gc::GCRuntime::markRuntime")
+        self.assertEqual(crashInfo.backtrace[8], "js::gc::GCRuntime::updatePointersToRelocatedCells")
+        self.assertEqual(crashInfo.backtrace[9], "js::gc::GCRuntime::compactPhase")
+        self.assertEqual(crashInfo.backtrace[10], "js::gc::GCRuntime::incrementalCollectSlice")
+        self.assertEqual(crashInfo.backtrace[11], "js::gc::GCRuntime::gcCycle")
+        self.assertEqual(crashInfo.backtrace[12], "js::gc::GCRuntime::collect")
+        self.assertEqual(crashInfo.backtrace[13], "js::gc::GCRuntime::runDebugGC")
+        self.assertEqual(crashInfo.backtrace[14], "js::gc::GCRuntime::gcIfNeededPerAllocation")
+        self.assertEqual(crashInfo.backtrace[15], "js::gc::GCRuntime::checkAllocatorState")
+        self.assertEqual(crashInfo.backtrace[16], "js::Allocate")
+        self.assertEqual(crashInfo.backtrace[17], "js::ArrayObject::createArrayInternal")
+        self.assertEqual(crashInfo.backtrace[18], "js::ArrayObject::createArray")
+        self.assertEqual(crashInfo.backtrace[19], "NewArray")
+        self.assertEqual(crashInfo.backtrace[20], "NewArrayTryUseGroup")
+        self.assertEqual(crashInfo.backtrace[21], "js::NewFullyAllocatedArrayTryUseGroup")
+        self.assertEqual(crashInfo.backtrace[22], "js::jit::NewArrayWithGroup")
+        self.assertEqual(crashInfo.backtrace[23], "??")
+        self.assertEqual(crashInfo.backtrace[24], "??")
+
+        self.assertEqual(crashInfo.crashInstruction, "mov rax,qword ptr [rcx-8]")
+        self.assertEqual(crashInfo.registers["rax"], long(0x0000000000000002))
+        self.assertEqual(crashInfo.registers["rbx"], long(0x000000000207a020))
+        self.assertEqual(crashInfo.registers["rcx"], long(0xe5e5e5e5e5e5e5e5))
+        self.assertEqual(crashInfo.registers["rdx"], long(0x000000000041af58))
+        self.assertEqual(crashInfo.registers["rsi"], long(0x0000000000000000))
+        self.assertEqual(crashInfo.registers["rdi"], long(0x000000000041af58))
+        self.assertEqual(crashInfo.registers["rip"], long(0x00000001401bca44))
+        self.assertEqual(crashInfo.registers["rsp"], long(0x000000000041ab80))
+        self.assertEqual(crashInfo.registers["rbp"], long(0x000000000041af58))
+        self.assertEqual(crashInfo.registers["r8"], long(0x0000000003aaf000))
+        self.assertEqual(crashInfo.registers["r9"], long(0x000000000041ac40))
+        self.assertEqual(crashInfo.registers["r10"], long(0x0000000003a786c3))
+        self.assertEqual(crashInfo.registers["r11"], long(0x000000000000000e))
+        self.assertEqual(crashInfo.registers["r12"], long(0x0000000000000001))
+        self.assertEqual(crashInfo.registers["r13"], long(0x0000000003aa5000))
+        self.assertEqual(crashInfo.registers["r14"], long(0x0000000002025430))
+        self.assertEqual(crashInfo.registers["r15"], long(0x000000000041af58))
+
+        self.assertEqual(crashInfo.crashAddress, long(0xffffffffffffffff))
+
+class CDBSelectorTest5(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86-64", "windows")
+
+        with open('cdb-crash-report-example-5.txt', 'r') as f:
+            crashData = f.read().splitlines()
+
+        crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
+        self.assertEqual(crashInfo.crashAddress, long(0xffffffffffffffff))
+
+# Test 6 is an example with 64-bit js debug shell crashing with:
+#     Exception Faulting Address: 0x0
+#     Second Chance Exception Type: STATUS_ACCESS_VIOLATION (0xC0000005)
+#     Faulting Instruction:00000001`3f523043 cmp byte ptr [rdx+rax],0
+#     Exploitability Classification: PROBABLY_NOT_EXPLOITABLE
+class CDBParserTestCrash6(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86-64", "windows")
+
+        with open('cdb-crash-report-example-6.txt', 'r') as f:
+            crashInfo = CDBCrashInfo([], [], config, f.read().splitlines())
+
+        self.assertEqual(len(crashInfo.backtrace), 34)
+        self.assertEqual(crashInfo.backtrace[0], "js::ExpandErrorArgumentsVA")
+        self.assertEqual(crashInfo.backtrace[1], "js::ReportErrorNumberVA")
+        self.assertEqual(crashInfo.backtrace[2], "JS_ReportErrorFlagsAndNumber")
+        self.assertEqual(crashInfo.backtrace[3], "js::EnterDebuggeeNoExecute::reportIfFoundInStack")
+        self.assertEqual(crashInfo.backtrace[4], "js::Debugger::slowPathCheckNoExecute")
+        self.assertEqual(crashInfo.backtrace[5], "js::Debugger::checkNoExecute")
+        self.assertEqual(crashInfo.backtrace[6], "js::RunScript")
+        self.assertEqual(crashInfo.backtrace[7], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[8], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[9], "js::DirectProxyHandler::call")
+        self.assertEqual(crashInfo.backtrace[10], "js::CrossCompartmentWrapper::call")
+        self.assertEqual(crashInfo.backtrace[11], "js::Proxy::call")
+        self.assertEqual(crashInfo.backtrace[12], "js::proxy_Call")
+        self.assertEqual(crashInfo.backtrace[13], "js::CallJSNative")
+        self.assertEqual(crashInfo.backtrace[14], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[15], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[16], "js::jit::DoCallFallback")
+        self.assertEqual(crashInfo.backtrace[17], "??")
+        self.assertEqual(crashInfo.backtrace[18], "??")
+        self.assertEqual(crashInfo.backtrace[19], "??")
+        self.assertEqual(crashInfo.backtrace[20], "??")
+        self.assertEqual(crashInfo.backtrace[21], "??")
+        self.assertEqual(crashInfo.backtrace[22], "??")
+        self.assertEqual(crashInfo.backtrace[23], "??")
+        self.assertEqual(crashInfo.backtrace[24], "??")
+        self.assertEqual(crashInfo.backtrace[25], "??")
+        self.assertEqual(crashInfo.backtrace[26], "??")
+        self.assertEqual(crashInfo.backtrace[27], "??")
+        self.assertEqual(crashInfo.backtrace[28], "DoCallFallbackInfo")
+        self.assertEqual(crashInfo.backtrace[29], "??")
+        self.assertEqual(crashInfo.backtrace[30], "??")
+        self.assertEqual(crashInfo.backtrace[31], "??")
+        self.assertEqual(crashInfo.backtrace[32], "??")
+        self.assertEqual(crashInfo.backtrace[33], "??")
+
+        self.assertEqual(crashInfo.crashInstruction, "cmp byte ptr [rdx+rax],0")
+        self.assertEqual(crashInfo.registers["rax"], long(0x0000000000000000))
+        self.assertEqual(crashInfo.registers["rbx"], long(0x0000000000000000))
+        self.assertEqual(crashInfo.registers["rcx"], long(0x0000000003cae900))
+        self.assertEqual(crashInfo.registers["rdx"], long(0x0000000000000000))
+        self.assertEqual(crashInfo.registers["rsi"], long(0x00000000002ab380))
+        self.assertEqual(crashInfo.registers["rdi"], long(0xffffffffffffffff))
+        self.assertEqual(crashInfo.registers["rip"], long(0x000000013f523043))
+        self.assertEqual(crashInfo.registers["rsp"], long(0x00000000002ab190))
+        self.assertEqual(crashInfo.registers["rbp"], long(0x00000000002ab290))
+        self.assertEqual(crashInfo.registers["r8"], long(0x0000000001cc29f7))
+        self.assertEqual(crashInfo.registers["r9"], long(0x00000000ffffffc0))
+        self.assertEqual(crashInfo.registers["r10"], long(0x0000000003cae000))
+        self.assertEqual(crashInfo.registers["r11"], long(0x0000000003cae900))
+        self.assertEqual(crashInfo.registers["r12"], long(0x0000000000000002))
+        self.assertEqual(crashInfo.registers["r13"], long(0x0000000000000000))
+        self.assertEqual(crashInfo.registers["r14"], long(0x00000000002ab4a8))
+        self.assertEqual(crashInfo.registers["r15"], long(0x0000000000000000))
+
+        self.assertEqual(crashInfo.crashAddress, long(0x0))
+
+class CDBSelectorTest6(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86-64", "windows")
+
+        with open('cdb-crash-report-example-6.txt', 'r') as f:
+            crashData = f.read().splitlines()
+
+        crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
+        self.assertEqual(crashInfo.crashAddress, long(0x0))
+
+# Test 7 is an example with 32-bit js debug shell crashing with:
+#     Exception Faulting Address: 0x0
+#     Second Chance Exception Type: STATUS_ACCESS_VIOLATION (0xC0000005)
+#     Faulting Instruction:001507e0 mov al,byte ptr [ecx]
+#     Exploitability Classification: PROBABLY_NOT_EXPLOITABLE
+class CDBParserTestCrash7(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86", "windows")
+
+        with open('cdb-crash-report-example-7.txt', 'r') as f:
+            crashInfo = CDBCrashInfo([], [], config, f.read().splitlines())
+
+        self.assertEqual(len(crashInfo.backtrace), 62)
+        self.assertEqual(crashInfo.backtrace[0], "js::ExpandErrorArgumentsVA")
+        self.assertEqual(crashInfo.backtrace[1], "js::ReportErrorNumberVA")
+        self.assertEqual(crashInfo.backtrace[2], "JS_ReportErrorFlagsAndNumber")
+        self.assertEqual(crashInfo.backtrace[3], "js::EnterDebuggeeNoExecute::reportIfFoundInStack")
+        self.assertEqual(crashInfo.backtrace[4], "js::Debugger::slowPathCheckNoExecute")
+        self.assertEqual(crashInfo.backtrace[5], "js::Debugger::checkNoExecute")
+        self.assertEqual(crashInfo.backtrace[6], "js::RunScript")
+        self.assertEqual(crashInfo.backtrace[7], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[8], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[9], "js::DirectProxyHandler::call")
+        self.assertEqual(crashInfo.backtrace[10], "js::CrossCompartmentWrapper::call")
+        self.assertEqual(crashInfo.backtrace[11], "js::Proxy::call")
+        self.assertEqual(crashInfo.backtrace[12], "js::proxy_Call")
+        self.assertEqual(crashInfo.backtrace[13], "js::CallJSNative")
+        self.assertEqual(crashInfo.backtrace[14], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[15], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[16], "js::jit::DoCallFallback")
+        self.assertEqual(crashInfo.backtrace[17], "??")
+        self.assertEqual(crashInfo.backtrace[18], "js::Activation::Activation")
+        self.assertEqual(crashInfo.backtrace[19], "EnterIon")
+        self.assertEqual(crashInfo.backtrace[20], "js::jit::IonCannon")
+        self.assertEqual(crashInfo.backtrace[21], "js::RunScript")
+        self.assertEqual(crashInfo.backtrace[22], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[23], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[24], "js::Debugger::fireDebuggerStatement")
+        self.assertEqual(crashInfo.backtrace[25], "js::Debugger::dispatchHook")
+        self.assertEqual(crashInfo.backtrace[26], "js::Debugger::slowPathOnDebuggerStatement")
+        self.assertEqual(crashInfo.backtrace[27], "js::jit::OnDebuggerStatement")
+        self.assertEqual(crashInfo.backtrace[28], "??")
+        self.assertEqual(crashInfo.backtrace[29], "EnterBaseline")
+        self.assertEqual(crashInfo.backtrace[30], "js::jit::EnterBaselineMethod")
+        self.assertEqual(crashInfo.backtrace[31], "js::RunScript")
+        self.assertEqual(crashInfo.backtrace[32], "js::ExecuteKernel")
+        self.assertEqual(crashInfo.backtrace[33], "EvalKernel")
+        self.assertEqual(crashInfo.backtrace[34], "js::IndirectEval")
+        self.assertEqual(crashInfo.backtrace[35], "js::CallJSNative")
+        self.assertEqual(crashInfo.backtrace[36], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[37], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[38], "js::DirectProxyHandler::call")
+        self.assertEqual(crashInfo.backtrace[39], "js::CrossCompartmentWrapper::call")
+        self.assertEqual(crashInfo.backtrace[40], "js::Proxy::call")
+        self.assertEqual(crashInfo.backtrace[41], "js::proxy_Call")
+        self.assertEqual(crashInfo.backtrace[42], "js::CallJSNative")
+        self.assertEqual(crashInfo.backtrace[43], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[44], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[45], "js::jit::DoCallFallback")
+        self.assertEqual(crashInfo.backtrace[46], "??")
+        self.assertEqual(crashInfo.backtrace[47], "EnterIon")
+        self.assertEqual(crashInfo.backtrace[48], "js::jit::IonCannon")
+        self.assertEqual(crashInfo.backtrace[49], "js::RunScript")
+        self.assertEqual(crashInfo.backtrace[50], "js::ExecuteKernel")
+        self.assertEqual(crashInfo.backtrace[51], "js::Execute")
+        self.assertEqual(crashInfo.backtrace[52], "ExecuteScript")
+        self.assertEqual(crashInfo.backtrace[53], "JS_ExecuteScript")
+        self.assertEqual(crashInfo.backtrace[54], "RunFile")
+        self.assertEqual(crashInfo.backtrace[55], "Process")
+        self.assertEqual(crashInfo.backtrace[56], "ProcessArgs")
+        self.assertEqual(crashInfo.backtrace[57], "Shell")
+        self.assertEqual(crashInfo.backtrace[58], "main")
+        self.assertEqual(crashInfo.backtrace[59], "__tmainCRTStartup")
+        self.assertEqual(crashInfo.backtrace[60], "mainCRTStartup")
+        self.assertEqual(crashInfo.backtrace[61], "BaseThreadInitThunk")
+
+        self.assertEqual(crashInfo.crashInstruction, "mov al,byte ptr [ecx]")
+        self.assertEqual(crashInfo.registers["eax"], long(0x00000001))
+        self.assertEqual(crashInfo.registers["ebx"], long(0x0116daa8))
+        self.assertEqual(crashInfo.registers["ecx"], long(0x00000000))
+        self.assertEqual(crashInfo.registers["edx"], long(0x00000000))
+        self.assertEqual(crashInfo.registers["esi"], long(0x00000000))
+        self.assertEqual(crashInfo.registers["edi"], long(0x0116db2c))
+        self.assertEqual(crashInfo.registers["eip"], long(0x001507e0))
+        self.assertEqual(crashInfo.registers["esp"], long(0x0116d9e4))
+        self.assertEqual(crashInfo.registers["ebp"], long(0x0116da70))
+
+        self.assertEqual(crashInfo.crashAddress, long(0x0))
+
+class CDBSelectorTest7(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86", "windows")
+
+        with open('cdb-crash-report-example-7.txt', 'r') as f:
+            crashData = f.read().splitlines()
+
+        crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
+        self.assertEqual(crashInfo.crashAddress, long(0x0))
+
 class UBSanParserTestCrash(unittest.TestCase):
     def runTest(self):
         config = ProgramConfiguration("test", "x86", "linux")

--- a/FTB/Signatures/tests.py
+++ b/FTB/Signatures/tests.py
@@ -678,6 +678,11 @@ class AppleSelectorTest(unittest.TestCase):
         crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
         self.assertEqual(crashInfo.crashAddress, long(0x00007fff5f3fff98))
 
+# Test 1 is an example with 64-bit js opt shell crashing with:
+#     Exception Faulting Address: 0x7fef86c13e4
+#     Second Chance Exception Type: STATUS_BREAKPOINT (0x80000003)
+#     Faulting Instruction:000007fe`f86c13e4 int 3
+#     Exploitability Classification: UNKNOWN
 class CDBParserTestCrash1(unittest.TestCase):
     def runTest(self):
         config = ProgramConfiguration("test", "x86-64", "windows")
@@ -719,6 +724,11 @@ class CDBSelectorTest1(unittest.TestCase):
         crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
         self.assertEqual(crashInfo.crashAddress, long(0x000007fef86c13e4))
 
+# Test 2 is an example with 64-bit js debug shell crashing with:
+#     Exception Faulting Address: 0x1405e4703
+#     Second Chance Exception Type: STATUS_BREAKPOINT (0x80000003)
+#     Faulting Instruction:00000001`405e4703 int 3
+#     Exploitability Classification: UNKNOWN
 class CDBParserTestCrash2(unittest.TestCase):
     def runTest(self):
         config = ProgramConfiguration("test", "x86-64", "windows")
@@ -757,6 +767,11 @@ class CDBSelectorTest2(unittest.TestCase):
         crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
         self.assertEqual(crashInfo.crashAddress, long(0x00000001405e4703))
 
+# Test 3 is an example with 32-bit js debug shell crashing with:
+#     Exception Faulting Address: 0x1206fbd
+#     Second Chance Exception Type: STATUS_BREAKPOINT (0x80000003)
+#     Faulting Instruction:01206fbd int 3
+#     Exploitability Classification: UNKNOWN
 class CDBParserTestCrash3(unittest.TestCase):
     def runTest(self):
         config = ProgramConfiguration("test", "x86", "windows")

--- a/FTB/Signatures/tests.py
+++ b/FTB/Signatures/tests.py
@@ -764,7 +764,7 @@ class CDBParserTestCrash3(unittest.TestCase):
         with open('cdb-crash-report-example-3.txt', 'r') as f:
             crashInfo = CDBCrashInfo([], [], config, f.read().splitlines())
 
-        self.assertEqual(len(crashInfo.backtrace), 52)
+        self.assertEqual(len(crashInfo.backtrace), 50)
         self.assertEqual(crashInfo.backtrace[0], "JS::Value::isMagic")
         self.assertEqual(crashInfo.backtrace[1], "js::jit::InvokeFunction")
         self.assertEqual(crashInfo.backtrace[2], "??")
@@ -815,8 +815,6 @@ class CDBParserTestCrash3(unittest.TestCase):
         self.assertEqual(crashInfo.backtrace[47], "__tmainCRTStartup")
         self.assertEqual(crashInfo.backtrace[48], "mainCRTStartup")
         self.assertEqual(crashInfo.backtrace[49], "BaseThreadInitThunk")
-        self.assertEqual(crashInfo.backtrace[50], "RtlInitializeExceptionChain")
-        self.assertEqual(crashInfo.backtrace[51], "RtlInitializeExceptionChain")
 
         self.assertEqual(crashInfo.crashAddress, long(0x0000000001206fbd))
 

--- a/FTB/Signatures/tests.py
+++ b/FTB/Signatures/tests.py
@@ -712,6 +712,24 @@ class CDBParserTestCrash1(unittest.TestCase):
         self.assertEqual(crashInfo.backtrace[18], "js::jit::DoWarmUpCounterFallback")
         self.assertEqual(crashInfo.backtrace[19], "??")
 
+        self.assertEqual(crashInfo.registers["rax"], long(0x0000000000000000))
+        self.assertEqual(crashInfo.registers["rbx"], long(0x0000000000008000))
+        self.assertEqual(crashInfo.registers["rcx"], long(0x00000000000005af))
+        self.assertEqual(crashInfo.registers["rdx"], long(0x0000000000000000))
+        self.assertEqual(crashInfo.registers["rsi"], long(0x0000000008c52000))
+        self.assertEqual(crashInfo.registers["rdi"], long(0x0000000000008000))
+        self.assertEqual(crashInfo.registers["rip"], long(0x000007fef86c13e4))
+        self.assertEqual(crashInfo.registers["rsp"], long(0x000000000033bb10))
+        self.assertEqual(crashInfo.registers["rbp"], long(0x0000000000000008))
+        self.assertEqual(crashInfo.registers["r8"], long(0x0000000077440000))
+        self.assertEqual(crashInfo.registers["r9"], long(0x00000000000003a6))
+        self.assertEqual(crashInfo.registers["r10"], long(0x00000000c000012d))
+        self.assertEqual(crashInfo.registers["r11"], long(0x0000000000000246))
+        self.assertEqual(crashInfo.registers["r12"], long(0x0000000000000008))
+        self.assertEqual(crashInfo.registers["r13"], long(0x0000000000500040))
+        self.assertEqual(crashInfo.registers["r14"], long(0x0000000008c007e0))
+        self.assertEqual(crashInfo.registers["r15"], long(0x0000000000000000))
+
         self.assertEqual(crashInfo.crashAddress, long(0x7fef86c13e4))
 
 class CDBSelectorTest1(unittest.TestCase):
@@ -754,6 +772,24 @@ class CDBParserTestCrash2(unittest.TestCase):
         self.assertEqual(crashInfo.backtrace[14], "??")
         self.assertEqual(crashInfo.backtrace[15], "??")
         self.assertEqual(crashInfo.backtrace[16], "??")
+
+        self.assertEqual(crashInfo.registers["rax"], long(0x0000000000000000))
+        self.assertEqual(crashInfo.registers["rbx"], long(0x00000000072f5220))
+        self.assertEqual(crashInfo.registers["rcx"], long(0x000007fef884b780))
+        self.assertEqual(crashInfo.registers["rdx"], long(0x0000000000000000))
+        self.assertEqual(crashInfo.registers["rsi"], long(0x0000000002016400))
+        self.assertEqual(crashInfo.registers["rdi"], long(0x00000000071eb5bc))
+        self.assertEqual(crashInfo.registers["rip"], long(0x00000001405e4703))
+        self.assertEqual(crashInfo.registers["rsp"], long(0x00000000003ecb80))
+        self.assertEqual(crashInfo.registers["rbp"], long(0x00000000003ecbd0))
+        self.assertEqual(crashInfo.registers["r8"], long(0x00000000003e8c48))
+        self.assertEqual(crashInfo.registers["r9"], long(0x00000000003ecbd0))
+        self.assertEqual(crashInfo.registers["r10"], long(0x0000000000000000))
+        self.assertEqual(crashInfo.registers["r11"], long(0x0000000000000246))
+        self.assertEqual(crashInfo.registers["r12"], long(0x0000000000000008))
+        self.assertEqual(crashInfo.registers["r13"], long(0x0000000000000000))
+        self.assertEqual(crashInfo.registers["r14"], long(0x00000000003ecc68))
+        self.assertEqual(crashInfo.registers["r15"], long(0x0000000000000000))
 
         self.assertEqual(crashInfo.crashAddress, long(0x1405e4703))
 
@@ -830,6 +866,16 @@ class CDBParserTestCrash3(unittest.TestCase):
         self.assertEqual(crashInfo.backtrace[47], "__tmainCRTStartup")
         self.assertEqual(crashInfo.backtrace[48], "mainCRTStartup")
         self.assertEqual(crashInfo.backtrace[49], "BaseThreadInitThunk")
+
+        self.assertEqual(crashInfo.registers["eax"], long(0x00000000))
+        self.assertEqual(crashInfo.registers["ebx"], long(0x00000000))
+        self.assertEqual(crashInfo.registers["ecx"], long(0x12630a6d))
+        self.assertEqual(crashInfo.registers["edx"], long(0x00000012))
+        self.assertEqual(crashInfo.registers["esi"], long(0x00c6b180))
+        self.assertEqual(crashInfo.registers["edi"], long(0x00000000))
+        self.assertEqual(crashInfo.registers["eip"], long(0x01206fbd))
+        self.assertEqual(crashInfo.registers["esp"], long(0x0020d5b4))
+        self.assertEqual(crashInfo.registers["ebp"], long(0x0020d5bc))
 
         self.assertEqual(crashInfo.crashAddress, long(0x1206fbd))
 

--- a/FTB/Signatures/tests.py
+++ b/FTB/Signatures/tests.py
@@ -13,7 +13,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 '''
 import unittest
 from FTB.Signatures.CrashInfo import ASanCrashInfo, GDBCrashInfo, CrashInfo,\
-    NoCrashInfo, MinidumpCrashInfo, AppleCrashInfo
+    NoCrashInfo, MinidumpCrashInfo, AppleCrashInfo, CDBCrashInfo
 from FTB.Signatures.CrashSignature import CrashSignature
 from FTB.Signatures import RegisterHelper
 
@@ -677,6 +677,158 @@ class AppleSelectorTest(unittest.TestCase):
 
         crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
         self.assertEqual(crashInfo.crashAddress, long(0x00007fff5f3fff98))
+
+class CDBParserTestCrash1(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86-64", "windows")
+
+        with open('cdb-crash-report-example-1.txt', 'r') as f:
+            crashInfo = CDBCrashInfo([], [], config, f.read().splitlines())
+
+        self.assertEqual(len(crashInfo.backtrace), 20)
+        self.assertEqual(crashInfo.backtrace[0], "moz_abort")
+        self.assertEqual(crashInfo.backtrace[1], "arena_run_split")
+        self.assertEqual(crashInfo.backtrace[2], "arena_run_alloc")
+        self.assertEqual(crashInfo.backtrace[3], "arena_malloc_large")
+        self.assertEqual(crashInfo.backtrace[4], "arena_ralloc")
+        self.assertEqual(crashInfo.backtrace[5], "je_realloc")
+        self.assertEqual(crashInfo.backtrace[6], "mozilla::VectorBase")
+        self.assertEqual(crashInfo.backtrace[7], "js::jit::X86Encoding::BaseAssembler::X86InstructionFormatter::oneByteOp64")
+        self.assertEqual(crashInfo.backtrace[8], "js::jit::X86Encoding::BaseAssemblerX64::movq_mr")
+        self.assertEqual(crashInfo.backtrace[9], "js::jit::MacroAssemblerX64::load64")
+        self.assertEqual(crashInfo.backtrace[10], "js::jit::CodeGenerator::visitElements")
+        self.assertEqual(crashInfo.backtrace[11], "js::jit::CodeGenerator::generateBody")
+        self.assertEqual(crashInfo.backtrace[12], "js::jit::CodeGenerator::generate")
+        self.assertEqual(crashInfo.backtrace[13], "js::jit::GenerateCode")
+        self.assertEqual(crashInfo.backtrace[14], "js::jit::IonCompile")
+        self.assertEqual(crashInfo.backtrace[15], "js::jit::Compile")
+        self.assertEqual(crashInfo.backtrace[16], "js::jit::CompileFunctionForBaseline")
+        self.assertEqual(crashInfo.backtrace[17], "js::jit::EnsureCanEnterIon")
+        self.assertEqual(crashInfo.backtrace[18], "js::jit::DoWarmUpCounterFallback")
+        self.assertEqual(crashInfo.backtrace[19], "??")
+
+        self.assertEqual(crashInfo.crashAddress, long(0x000007fef86c13e4))
+
+class CDBSelectorTest1(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86-64", "windows")
+
+        with open('cdb-crash-report-example-1.txt', 'r') as f:
+            crashData = f.read().splitlines()
+
+        crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
+        self.assertEqual(crashInfo.crashAddress, long(0x000007fef86c13e4))
+
+class CDBParserTestCrash2(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86-64", "windows")
+
+        with open('cdb-crash-report-example-2.txt', 'r') as f:
+            crashInfo = CDBCrashInfo([], [], config, f.read().splitlines())
+
+        self.assertEqual(len(crashInfo.backtrace), 17)
+        self.assertEqual(crashInfo.backtrace[0], "js::jit::DoTypeMonitorFallback")
+        self.assertEqual(crashInfo.backtrace[1], "??")
+        self.assertEqual(crashInfo.backtrace[2], "??")
+        self.assertEqual(crashInfo.backtrace[3], "??")
+        self.assertEqual(crashInfo.backtrace[4], "??")
+        self.assertEqual(crashInfo.backtrace[5], "??")
+        self.assertEqual(crashInfo.backtrace[6], "??")
+        self.assertEqual(crashInfo.backtrace[7], "??")
+        self.assertEqual(crashInfo.backtrace[8], "??")
+        self.assertEqual(crashInfo.backtrace[9], "??")
+        self.assertEqual(crashInfo.backtrace[10], "DoTypeMonitorFallbackInfo")
+        self.assertEqual(crashInfo.backtrace[11], "??")
+        self.assertEqual(crashInfo.backtrace[12], "??")
+        self.assertEqual(crashInfo.backtrace[13], "??")
+        self.assertEqual(crashInfo.backtrace[14], "??")
+        self.assertEqual(crashInfo.backtrace[15], "??")
+        self.assertEqual(crashInfo.backtrace[16], "??")
+
+        self.assertEqual(crashInfo.crashAddress, long(0x00000001405e4703))
+
+class CDBSelectorTest2(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86-64", "windows")
+
+        with open('cdb-crash-report-example-2.txt', 'r') as f:
+            crashData = f.read().splitlines()
+
+        crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
+        self.assertEqual(crashInfo.crashAddress, long(0x00000001405e4703))
+
+class CDBParserTestCrash3(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86-64", "windows")
+
+        with open('cdb-crash-report-example-3.txt', 'r') as f:
+            crashInfo = CDBCrashInfo([], [], config, f.read().splitlines())
+
+        self.assertEqual(len(crashInfo.backtrace), 52)
+        self.assertEqual(crashInfo.backtrace[0], "JS::Value::isMagic")
+        self.assertEqual(crashInfo.backtrace[1], "js::jit::InvokeFunction")
+        self.assertEqual(crashInfo.backtrace[2], "??")
+        self.assertEqual(crashInfo.backtrace[3], "EnterIon")
+        self.assertEqual(crashInfo.backtrace[4], "js::jit::IonCannon")
+        self.assertEqual(crashInfo.backtrace[5], "js::RunScript")
+        self.assertEqual(crashInfo.backtrace[6], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[7], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[8], "js::jit::InvokeFunction")
+        self.assertEqual(crashInfo.backtrace[9], "??")
+        self.assertEqual(crashInfo.backtrace[10], "EnterIon")
+        self.assertEqual(crashInfo.backtrace[11], "js::jit::IonCannon")
+        self.assertEqual(crashInfo.backtrace[12], "Interpret")
+        self.assertEqual(crashInfo.backtrace[13], "js::RunScript")
+        self.assertEqual(crashInfo.backtrace[14], "js::ExecuteKernel")
+        self.assertEqual(crashInfo.backtrace[15], "js::Execute")
+        self.assertEqual(crashInfo.backtrace[16], "Evaluate")
+        self.assertEqual(crashInfo.backtrace[17], "Evaluate")
+        self.assertEqual(crashInfo.backtrace[18], "JS::Evaluate")
+        self.assertEqual(crashInfo.backtrace[19], "EvalInContext")
+        self.assertEqual(crashInfo.backtrace[20], "??")
+        self.assertEqual(crashInfo.backtrace[21], "Print")
+        self.assertEqual(crashInfo.backtrace[22], "??")
+        self.assertEqual(crashInfo.backtrace[23], "??")
+        self.assertEqual(crashInfo.backtrace[24], "??")
+        self.assertEqual(crashInfo.backtrace[25], "??")
+        self.assertEqual(crashInfo.backtrace[26], "??")
+        self.assertEqual(crashInfo.backtrace[27], "??")
+        self.assertEqual(crashInfo.backtrace[28], "js::Activation::Activation")
+        self.assertEqual(crashInfo.backtrace[29], "EnterIon")
+        self.assertEqual(crashInfo.backtrace[30], "js::jit::IonCannon")
+        self.assertEqual(crashInfo.backtrace[31], "js::RunScript")
+        self.assertEqual(crashInfo.backtrace[32], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[33], "js::Invoke")
+        self.assertEqual(crashInfo.backtrace[34], "js::jit::DoCallFallback")
+        self.assertEqual(crashInfo.backtrace[35], "??")
+        self.assertEqual(crashInfo.backtrace[36], "EnterBaseline")
+        self.assertEqual(crashInfo.backtrace[37], "js::jit::EnterBaselineMethod")
+        self.assertEqual(crashInfo.backtrace[38], "js::RunScript")
+        self.assertEqual(crashInfo.backtrace[39], "js::ExecuteKernel")
+        self.assertEqual(crashInfo.backtrace[40], "js::Execute")
+        self.assertEqual(crashInfo.backtrace[41], "ExecuteScript")
+        self.assertEqual(crashInfo.backtrace[42], "JS_ExecuteScript")
+        self.assertEqual(crashInfo.backtrace[43], "RunFile")
+        self.assertEqual(crashInfo.backtrace[44], "ProcessArgs")
+        self.assertEqual(crashInfo.backtrace[45], "Shell")
+        self.assertEqual(crashInfo.backtrace[46], "main")
+        self.assertEqual(crashInfo.backtrace[47], "__tmainCRTStartup")
+        self.assertEqual(crashInfo.backtrace[48], "mainCRTStartup")
+        self.assertEqual(crashInfo.backtrace[49], "BaseThreadInitThunk")
+        self.assertEqual(crashInfo.backtrace[50], "RtlInitializeExceptionChain")
+        self.assertEqual(crashInfo.backtrace[51], "RtlInitializeExceptionChain")
+
+        self.assertEqual(crashInfo.crashAddress, long(0x0000000001206fbd))
+
+class CDBSelectorTest3(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration("test", "x86-64", "windows")
+
+        with open('cdb-crash-report-example-3.txt', 'r') as f:
+            crashData = f.read().splitlines()
+
+        crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
+        self.assertEqual(crashInfo.crashAddress, long(0x0000000001206fbd))
 
 class UBSanParserTestCrash(unittest.TestCase):
     def runTest(self):

--- a/FTB/Signatures/tests.py
+++ b/FTB/Signatures/tests.py
@@ -759,7 +759,7 @@ class CDBSelectorTest2(unittest.TestCase):
 
 class CDBParserTestCrash3(unittest.TestCase):
     def runTest(self):
-        config = ProgramConfiguration("test", "x86-64", "windows")
+        config = ProgramConfiguration("test", "x86", "windows")
 
         with open('cdb-crash-report-example-3.txt', 'r') as f:
             crashInfo = CDBCrashInfo([], [], config, f.read().splitlines())
@@ -820,7 +820,7 @@ class CDBParserTestCrash3(unittest.TestCase):
 
 class CDBSelectorTest3(unittest.TestCase):
     def runTest(self):
-        config = ProgramConfiguration("test", "x86-64", "windows")
+        config = ProgramConfiguration("test", "x86", "windows")
 
         with open('cdb-crash-report-example-3.txt', 'r') as f:
             crashData = f.read().splitlines()

--- a/FTB/Signatures/tests.py
+++ b/FTB/Signatures/tests.py
@@ -712,6 +712,7 @@ class CDBParserTestCrash1(unittest.TestCase):
         self.assertEqual(crashInfo.backtrace[18], "js::jit::DoWarmUpCounterFallback")
         self.assertEqual(crashInfo.backtrace[19], "??")
 
+        self.assertEqual(crashInfo.crashInstruction, "int 3")
         self.assertEqual(crashInfo.registers["rax"], long(0x0000000000000000))
         self.assertEqual(crashInfo.registers["rbx"], long(0x0000000000008000))
         self.assertEqual(crashInfo.registers["rcx"], long(0x00000000000005af))
@@ -773,6 +774,7 @@ class CDBParserTestCrash2(unittest.TestCase):
         self.assertEqual(crashInfo.backtrace[15], "??")
         self.assertEqual(crashInfo.backtrace[16], "??")
 
+        self.assertEqual(crashInfo.crashInstruction, "int 3")
         self.assertEqual(crashInfo.registers["rax"], long(0x0000000000000000))
         self.assertEqual(crashInfo.registers["rbx"], long(0x00000000072f5220))
         self.assertEqual(crashInfo.registers["rcx"], long(0x000007fef884b780))
@@ -867,6 +869,7 @@ class CDBParserTestCrash3(unittest.TestCase):
         self.assertEqual(crashInfo.backtrace[48], "mainCRTStartup")
         self.assertEqual(crashInfo.backtrace[49], "BaseThreadInitThunk")
 
+        self.assertEqual(crashInfo.crashInstruction, "int 3")
         self.assertEqual(crashInfo.registers["eax"], long(0x00000000))
         self.assertEqual(crashInfo.registers["ebx"], long(0x00000000))
         self.assertEqual(crashInfo.registers["ecx"], long(0x12630a6d))

--- a/FTB/Signatures/tests.py
+++ b/FTB/Signatures/tests.py
@@ -712,7 +712,7 @@ class CDBParserTestCrash1(unittest.TestCase):
         self.assertEqual(crashInfo.backtrace[18], "js::jit::DoWarmUpCounterFallback")
         self.assertEqual(crashInfo.backtrace[19], "??")
 
-        self.assertEqual(crashInfo.crashAddress, long(0x000007fef86c13e4))
+        self.assertEqual(crashInfo.crashAddress, long(0x7fef86c13e4))
 
 class CDBSelectorTest1(unittest.TestCase):
     def runTest(self):
@@ -722,7 +722,7 @@ class CDBSelectorTest1(unittest.TestCase):
             crashData = f.read().splitlines()
 
         crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
-        self.assertEqual(crashInfo.crashAddress, long(0x000007fef86c13e4))
+        self.assertEqual(crashInfo.crashAddress, long(0x7fef86c13e4))
 
 # Test 2 is an example with 64-bit js debug shell crashing with:
 #     Exception Faulting Address: 0x1405e4703
@@ -755,7 +755,7 @@ class CDBParserTestCrash2(unittest.TestCase):
         self.assertEqual(crashInfo.backtrace[15], "??")
         self.assertEqual(crashInfo.backtrace[16], "??")
 
-        self.assertEqual(crashInfo.crashAddress, long(0x00000001405e4703))
+        self.assertEqual(crashInfo.crashAddress, long(0x1405e4703))
 
 class CDBSelectorTest2(unittest.TestCase):
     def runTest(self):
@@ -765,7 +765,7 @@ class CDBSelectorTest2(unittest.TestCase):
             crashData = f.read().splitlines()
 
         crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
-        self.assertEqual(crashInfo.crashAddress, long(0x00000001405e4703))
+        self.assertEqual(crashInfo.crashAddress, long(0x1405e4703))
 
 # Test 3 is an example with 32-bit js debug shell crashing with:
 #     Exception Faulting Address: 0x1206fbd
@@ -831,7 +831,7 @@ class CDBParserTestCrash3(unittest.TestCase):
         self.assertEqual(crashInfo.backtrace[48], "mainCRTStartup")
         self.assertEqual(crashInfo.backtrace[49], "BaseThreadInitThunk")
 
-        self.assertEqual(crashInfo.crashAddress, long(0x0000000001206fbd))
+        self.assertEqual(crashInfo.crashAddress, long(0x1206fbd))
 
 class CDBSelectorTest3(unittest.TestCase):
     def runTest(self):
@@ -841,7 +841,7 @@ class CDBSelectorTest3(unittest.TestCase):
             crashData = f.read().splitlines()
 
         crashInfo = CrashInfo.fromRawCrashData([], [], config, crashData)
-        self.assertEqual(crashInfo.crashAddress, long(0x0000000001206fbd))
+        self.assertEqual(crashInfo.crashAddress, long(0x1206fbd))
 
 class UBSanParserTestCrash(unittest.TestCase):
     def runTest(self):


### PR DESCRIPTION
Here's a patch with tests that fixes issue #145.

Notes:
* cdb-crash-report-example-1.txt shows cdb commands and output prior to Mozlando (end-2015) updates.
* cdb-crash-report-example-2.txt shows cdb commands and output after Mozlando (end-2015) updates.
* This parses the !exploitable output. Sometimes cdb.exe is stupid and fails to extract the stack, but !exploitable works fine in the same cdb run. See cdb-crash-report-example-3.txt
* We might want to propagate !exploitable's exploitability report (look for Exploitability Classification) up to FuzzManager, and this should probably be another pull request. How should this be started, though?

Jesse's pull request #151 was very useful in adapting this for cdb.exe. Thanks for the suggestion!

To make these cdb tests work, I copied the cdb test files to the parent FuzzManager folder, then ran:

python -m unittest discover FTB/Signatures/

and whittled away at the cdb failures till there were none left.