### PR TITLE
Allow EC2SpotManager to also start instance-store images.

### DIFF
--- a/server/ec2spotmanager/management/commands/start_monitoring_daemon.py
+++ b/server/ec2spotmanager/management/commands/start_monitoring_daemon.py
@@ -308,7 +308,7 @@ class Command(NoArgsCommand):
 
             try:
                 logger.info("[Pool %d] Creating %s instances..." % (pool.id, count))
-                boto_instances = cluster.create_spot(config.ec2_max_price, tags=config.ec2_tags, delete_on_termination=True, timeout=20 * 60)
+                boto_instances = cluster.create_spot(config.ec2_max_price, tags=config.ec2_tags, root_device_type=config.ec2_root_device_type, delete_on_termination=True, timeout=20 * 60)
                 canceled_requests = count - len(boto_instances)
 
                 logger.info("[Pool %d] Successfully created %s instances, %s requests timed out and were canceled" % (pool.id, len(boto_instances), canceled_requests))

--- a/server/ec2spotmanager/templates/config/edit.html
+++ b/server/ec2spotmanager/templates/config/edit.html
@@ -69,6 +69,11 @@
             <input id="id_ec2_image_name" class="form-control" name="ec2_image_name" type="text" value="{{ config.ec2_image_name|default:"" }}">
             <br/>
 
+            <label for="id_ec2_root_device_type">EC2 Root Device Type</label><br/>
+            <!-- Not sure how to change this to a checkbox: -->
+            <input id="id_ec2_root_device_type" class="form-control" name="ec2_root_device_type" type="text" value="{{ config.ec2_root_device_type|default:"ebs" }}">
+            <br/>
+
             <label for="id_ec2_userdata">EC2 Userdata Script</label><br/>
 	    <textarea id="id_ec2_userdata" class="form-control" name="ec2_userdata" spellcheck='false'>{{ config.ec2_userdata|default:"" }}</textarea>
             <br/>

--- a/server/ec2spotmanager/templates/config/view.html
+++ b/server/ec2spotmanager/templates/config/view.html
@@ -28,6 +28,7 @@
 		<tr><td>EC2 Security Groups</td><td>{% if config.ec2_security_groups %} {{ config.ec2_security_groups }} {% else %} Not specified {% endif %}</td></tr>
 		<tr><td>EC2 Instance Type</td><td>{% if config.ec2_instance_type %} {{ config.ec2_instance_type }} {% else %} Not specified {% endif %}</td></tr>
 		<tr><td>EC2 Image Name</td><td>{% if config.ec2_image_name %} {{ config.ec2_image_name }} {% else %} Not specified {% endif %}</td></tr>
+		<tr><td>EC2 Root Device Type</td><td>{% if config.ec2_root_device_type %} {{ config.ec2_root_device_type }} {% else %} Not specified {% endif %}</td></tr>
 		<tr><td>EC2 Userdata File</td><td>{% if config.ec2_userdata_file %} {{ config.ec2_userdata_file }} {% else %} Not specified {% endif %}</td></tr>
 		<tr><td>EC2 Userdata Macros</td><td>{% if config.ec2_userdata_macros %} {{ config.ec2_userdata_macros }} {% else %} Not specified {% endif %}</td></tr>
 		<tr><td>EC2 Allowed Regions</td><td>{% if config.ec2_allowed_regions %} {{ config.ec2_allowed_regions }} {% else %} Not specified {% endif %}</td></tr>

--- a/server/ec2spotmanager/views.py
+++ b/server/ec2spotmanager/views.py
@@ -333,6 +333,12 @@ def __handleConfigPOST(request, config):
     else:
         config.ec2_image_name = None
 
+    # These will need to be changed if the form becomes a checkbox
+    if request.POST['ec2_root_device_type']:
+        config.ec2_root_device_type = request.POST['ec2_root_device_type']
+    else:
+        config.ec2_root_device_type = 'ebs'
+
     if request.POST['ec2_max_price']:
         config.ec2_max_price = float(request.POST['ec2_max_price'])
     else:


### PR DESCRIPTION
Laniakea supports instance-store images:

https://github.com/MozillaSecurity/laniakea/blob/master/laniakea.py#L67
https://github.com/MozillaSecurity/laniakea/blob/db3f397a3f78f929aa205711fb723e41fefadaa0/core/manager.py#L109

It would be nice if EC2SpotManager could start up instance-store images as well.

By default, we use EBS instances with -root-device-type=ebs, so EC2SpotManager should be able to pass in -root-device-type=instance_store if the EC2 Image Name is an instance-store image.

Note that the code in the PR does not yet work properly. I don't know how to switch the form for Root Device Type to a checkbox, but ideally we should have one probably named "Instance-store image" near these:

[View spot pool](https://github.com/MozillaSecurity/FuzzManager/blob/f58ef759db5e733aad182d27fdecc3468dbe28d3/server/ec2spotmanager/templates/config/view.html#L30)
[Edit spot pool](https://github.com/MozillaSecurity/FuzzManager/blob/f58ef759db5e733aad182d27fdecc3468dbe28d3/server/ec2spotmanager/templates/config/edit.html#L68)

Suggestions welcome!
