### PR TITLE
Bump numpy to version 1.11.2 to aid releng setup.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.7.1
-numpy==1.9.1
+numpy==1.11.2
 djangorestframework==2.4.4
 requests>=2.5.0
 lockfile>=0.8


### PR DESCRIPTION
I've run FuzzManager tests with numpy 1.11.2 on Mac and Linux using:

python -m unittest discover FTB/Signatures

and did not seem to run into issues.