### PR TITLE
Extend capabilities of the CrashManager REST API

### DIFF
--- a/server/crashmanager/serializers.py
+++ b/server/crashmanager/serializers.py
@@ -4,26 +4,31 @@ from django.core.files.base import ContentFile
 from django.forms import widgets
 import hashlib
 from rest_framework import serializers
+from rest_framework.exceptions import APIException
 
 from FTB.ProgramConfiguration import ProgramConfiguration
 from FTB.Signatures.CrashInfo import CrashInfo
 from crashmanager.models import CrashEntry, Bucket, Platform, Product, OS, TestCase, Client, Tool
 
+class InvalidArgumentException(APIException):
+    status_code = 400
 
 class CrashEntrySerializer(serializers.ModelSerializer):
     # We need to redefine several fields explicitly because we flatten our
     # foreign keys into these fields instead of using primary keys, hyperlinks
     # or slug fields. All of the other solutions would require the client to
     # create these instances first and issue multiple requests in total.
-    platform = serializers.CharField(max_length=63)
-    product = serializers.CharField(max_length=63)
+    #
+    # write_only here means don't try to read it automatically in super().to_native()
+    platform = serializers.CharField(max_length=63, write_only=True)
+    product = serializers.CharField(max_length=63, write_only=True)
     product_version = serializers.CharField(max_length=63, required=False, write_only=True)
-    os = serializers.CharField(max_length=63)
-    client = serializers.CharField(max_length=255)
-    tool = serializers.CharField(max_length=63)
+    os = serializers.CharField(max_length=63, write_only=True)
+    client = serializers.CharField(max_length=255, write_only=True)
+    tool = serializers.CharField(max_length=63, write_only=True)
     testcase = serializers.CharField(widget=widgets.Textarea, required=False)
     testcase_ext = serializers.CharField(required=False, write_only=True)
-    testcase_quality = serializers.CharField(required=False, default=0, write_only=True)
+    testcase_quality = serializers.IntegerField(required=False, default=0, write_only=True)
     testcase_isbinary = serializers.BooleanField(required=False, default=False, write_only=True)
 
     class Meta:
@@ -32,8 +37,9 @@ class CrashEntrySerializer(serializers.ModelSerializer):
                   'rawStdout', 'rawStderr', 'rawCrashData', 'metadata',
                   'testcase', 'testcase_ext', 'testcase_quality', 'testcase_isbinary',
                   'platform', 'product', 'product_version', 'os', 'client', 'tool',
-                  'env', 'args'
+                  'env', 'args', 'bucket', 'id'
                   )
+        read_only_fields = ('bucket', 'id')
 
     def to_native(self, obj):
         '''
@@ -70,6 +76,10 @@ class CrashEntrySerializer(serializers.ModelSerializer):
         if instance:
             # Not allowed to update existing instances
             return instance
+
+        missing_keys = {'rawStdout', 'rawStderr', 'rawCrashData'} - set(attrs.keys())
+        if missing_keys:
+            raise InvalidArgumentException({key: ["This field is required."] for key in missing_keys})
 
         product = attrs.pop('product', None)
         product_version = attrs.pop('product_version', None)
@@ -151,7 +161,23 @@ class CrashEntrySerializer(serializers.ModelSerializer):
 
 
 class BucketSerializer(serializers.ModelSerializer):
-    bug = serializers.SlugRelatedField(slug_field="externalId")
+    bug = serializers.SlugRelatedField(slug_field="externalId", read_only=True)
+    # write_only here means don't try to read it automatically in super().to_native()
+    # size and best_quality are annotations, so must be set manually
+    size = serializers.IntegerField(write_only=True)
+    best_quality = serializers.IntegerField(write_only=True)
+
     class Meta:
         model = Bucket
-        fields = ('bug', 'signature')
+        fields = ('best_quality', 'bug', 'frequent', 'id', 'permanent', 'shortDescription', 'signature', 'size')
+        read_only_fields = ('id', 'frequent', 'permanent', 'shortDescription', 'signature')
+
+    def to_native(self, obj):
+        serialized = super(BucketSerializer, self).to_native(obj)
+        if obj is not None:
+            serialized["size"] = obj.size
+            serialized["best_quality"] = obj.quality
+            # setting best_crash requires knowing whether the bucket query was restricted eg. by tool
+            # see note in BucketAnnotateFilterBackend
+
+        return serialized

--- a/server/crashmanager/urls.py
+++ b/server/crashmanager/urls.py
@@ -7,7 +7,8 @@ from server import settings
 
 
 router = routers.DefaultRouter()
-router.register(r'crashes', views.CrashEntryViewSet)
+router.register(r'crashes', views.CrashEntryViewSet, base_name='crashes')
+router.register(r'buckets', views.BucketViewSet, base_name='buckets')
 
 urlpatterns = patterns('',
     url(r'^rest/api-auth/', include('rest_framework.urls', namespace='rest_framework')),

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -140,7 +140,8 @@ STATIC_URL = '/static/'
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
-    )
+    ),
+    'PAGINATE_BY': 100
 }
 
 # Logging


### PR DESCRIPTION
* Implement HTTP PATCH support to /crashmanager/rest/crashes/{id}/ (Fixes #276)
    * this supports editing testcase_quality, which should be the only mutable field
* Add an interface for querying buckets (Fixes #265)
    * this adds /crashmanager/rest/buckets/ and /crashmanager/rest/buckets/{id}/
* Implement filtering of list APIs
    * addes a single query parameter 'query' which takes a JSON object describing QuerySet filters to apply
    * eg. /crashmanager/rest/crashes/?query={"op": "AND", "tool__name": "foo", "testcase__quality": 0}
* Enable pagination of list APIs (also affects EC2SpotManager REST API, although we are not using the list APIs there)