### PR TITLE
Switch from lockfile (deprecated) to fasteners (recommended).

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==1.7.1
 djangorestframework==2.4.4
-lockfile>=0.8
+fasteners>=0.14.1
 boto>=2.38.0
 django-chartjs>=1.0
 

--- a/server/crashmanager/management/common.py
+++ b/server/crashmanager/management/common.py
@@ -1,51 +1,54 @@
 # Ensure print() compatibility with Python 3
 from __future__ import print_function
 
+import functools
 from django.conf import settings
-from lockfile import FileLock, LockTimeout
+from fasteners import InterProcessLock
 import os
 import sys
 
-LOCK_PATH = os.path.join(settings.BASE_DIR, 'mgmt')
+LOCK_PATH = os.path.realpath(os.path.join(settings.BASE_DIR, 'mgmt'))
 
-class ManagementLock():
+class ManagementLock(object):
+
     def __init__(self):
         self.lock = None
-        
-    def aquire(self):
-        self.lock = FileLock(LOCK_PATH)
-        reported = False
-        
-        # Attempt to obtain a lock, retry every 10 seconds. Wait at most 10 minutes.
+
+    def acquire(self):
+        self.lock = InterProcessLock(LOCK_PATH)
+
+        # Attempt to obtain a lock, retry every 10 seconds. Wait at most 5 minutes.
         # The retrying is necessary so we can report on stderr that we are waiting
         # for a lock. Otherwise, a user trying to run the command manually might
         # get confused why the command execution is delayed.
-        for idx in range(0,30):  # @UnusedVariable
-            try:
-                self.lock.acquire(10)
-                return
-            except LockTimeout:
-                if not reported:
-                    print("Another management command is running, waiting for lock...", file=sys.stderr)
-                    reported = True
-        
-        raise RuntimeError("Failed to aquire lock.")
-    
+        if self.lock.acquire(blocking=False):
+            return
+        print("Another management command is running, waiting for lock...", file=sys.stderr)
+        if self.lock.acquire(delay=10, max_delay=10, timeout=300):
+            return
+
+        self.lock = None
+        raise RuntimeError("Failed to acquire lock.")
+
     def release(self):
-        if self.lock:
+        if self.lock is not None:
             self.lock.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
+        self.release()
+        return False
 
 
 def mgmt_lock_required(method):
     """
     Decorator to use on management methods that shouldn't run in parallel
     """
-    def decorator(self, *args, **options):
-        lock = ManagementLock()
-        lock.aquire()
-        try:
-            method(self, *args, **options)
-        finally:
-            lock.release()
-        return
-    return decorator 
+    @functools.wraps(method)
+    def decorator(*args, **options):
+        with ManagementLock():
+            return method(*args, **options)
+    return decorator


### PR DESCRIPTION
fasteners.InterProcessLock has some differences compared to lockfile.FileLock:
* does not lock between threads in the same process
* closing the lock file will release the lock (even another file descriptor)