### PR TITLE
Switch filter order for REST framework crashes view.

### DIFF
--- a/server/crashmanager/views.py
+++ b/server/crashmanager/views.py
@@ -1199,7 +1199,7 @@ class BucketViewSet(mixins.ListModelMixin,
     authentication_classes = (TokenAuthentication,)
     queryset = Bucket.objects.all()
     serializer_class = BucketSerializer
-    filter_backends = [JsonQueryFilterBackend, BucketAnnotateFilterBackend]
+    filter_backends = [BucketAnnotateFilterBackend, JsonQueryFilterBackend]
 
 def json_to_query(json_str):
     """


### PR DESCRIPTION
This allows using 'quality' in queries, which is added by an annotation
in the previous filter.