### PR TITLE
Setup FuzzManager deployment to PyPI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,10 @@ script:
     - python -m pytest -v --cov=. --cov-report term-missing
 after_success:
     - codecov -X gcov
+deploy:
+    provider: pypi
+    user: truber
+    password:
+        secure: Mu/+/+tbRRSNv2vHYrkOtjm9yCQl9luvdR3M7vq4BOEXd1NEZWR/sHpxOnV97QHINpGqQurUkHE8osrUBCXGkid2G/83HCkCmdwJ53PAdR+ddqz3TPeFX4EsW9j0YuiSABp9Em9EJ1LhIbUAo88GfY55xr1jPS0EaNS1bB8L5Yo=
+    on:
+        tags: true

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,21 @@
 from setuptools import setup
 
 if __name__ == '__main__':
-    setup(name='FuzzManager',
-          version='0.1.1',
+    setup(classifiers=[
+              "Intended Audience :: Developers",
+              "Topic :: Software Development :: Testing",
+              "Topic :: Security",
+              "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+              "Programming Language :: Python :: 2",
+              "Programming Language :: Python :: 2.7",
+          ],
+          description="A fuzzing management tools collection",
+          install_requires=['fasteners>=0.14.1', 'numpy>=1.11.2', 'requests>=2.5.0'],
+          keywords="fuzz fuzzing security test testing",
+          license="MPL 2.0",
+          maintainer="Mozilla Fuzzing Team",
+          maintainer_email="fuzzing@mozilla.com",
+          name='FuzzManager',
           packages=['Collector', 'CovReporter', 'EC2Reporter', 'FTB', 'FTB.Running', 'FTB.Signatures', 'Reporter'],
-          install_requires=['fasteners>=0.14.1', 'numpy>=1.11.2', 'requests>=2.5.0'])
+          url="https://github.com/MozillaSecurity/FuzzManager",
+          version='0.1.1')


### PR DESCRIPTION
This will automatically deploy new tagged versions of the FM client to
PyPI. (eg. `git tag 0.x.y && git push --follow-tags`)

This allows installation with pip: `pip install FuzzManager`