### PR TITLE
[CrashManager] Allow blank testcase_ext and product_version in crash …

### DIFF
--- a/server/crashmanager/serializers.py
+++ b/server/crashmanager/serializers.py
@@ -20,12 +20,12 @@ class CrashEntrySerializer(serializers.ModelSerializer):
     # create these instances first and issue multiple requests in total.
     platform = serializers.CharField(source='platform.name', max_length=63)
     product = serializers.CharField(source='product.name', max_length=63)
-    product_version = serializers.CharField(source='product.version', max_length=63, required=False)
+    product_version = serializers.CharField(source='product.version', max_length=63, required=False, allow_blank=True)
     os = serializers.CharField(source='os.name', max_length=63)
     client = serializers.CharField(source='client.name', max_length=255)
     tool = serializers.CharField(source='tool.name', max_length=63)
     testcase = serializers.CharField(source='testcase.test', required=False)
-    testcase_ext = serializers.CharField(required=False)
+    testcase_ext = serializers.CharField(required=False, allow_blank=True)
     testcase_quality = serializers.IntegerField(source='testcase.quality', required=False, default=0)
     testcase_isbinary = serializers.BooleanField(source='testcase.isBinary', required=False, default=False)
 


### PR DESCRIPTION
…submissions. This matches what is in the corresponding models.