### PR TITLE
python manage.py syncdb is no longer valid after django framework upgrade.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,33 @@ Afterwards, you should run the following commands
 
 ```
 $ cd server
-$ python manage.py syncdb
+$ python manage.py migrate
 ```
-During syncdb, make sure that you create a user as we need it later on.
+
+Create the fuzzmanager user.
+```
+$ python ./manage.py createsuperuser
+Username (leave blank to use 'kkuehl'): fuzzmanager
+Email address: fuzzmanager@internal.com
+Password:
+Password (again):
+Superuser created successfully.
+```
+Get fuzzmanager authorization token
+```
+$ python manage.py get_auth_token fuzzmanager
+4a253efa90f514bd89ae9a86d1dc264aa3133945
+```
+Since the fuzzmanager account is used as a service account, we need to set the http basic authentication password to the auth token.
+```
+htpasswd -cb .htpasswd fuzzmanager 4a253efa90f514bd89ae9a86d1dc264aa3133945`
+```
+This .htpasswd file can be stored anywhere on your hard drive.
+Your Apache AuthUserFile line should be updated to reflect your path.
+See examples/apache2/default.vhost for an example
+
+
+
 
 ### Local testing
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ python manage.py migrate
 Create the fuzzmanager user.
 ```
 $ python ./manage.py createsuperuser
-Username (leave blank to use 'kkuehl'): fuzzmanager
+Username (leave blank to use 'user'): fuzzmanager
 Email address: fuzzmanager@internal.com
 Password:
 Password (again):

--- a/server/contrib/README.md
+++ b/server/contrib/README.md
@@ -1,0 +1,80 @@
+## fuzzmanager_setup_helper.py
+The fuzzmanager_setup_helper.py will perform the following:
+* `python manage.py migrate`
+* create fuzzmanager super user account
+* Obtain fuzzmanager auth_token
+* Create .htpasswd file and create fuzzmanager user account with auth_token as password 
+* Create .fuzzmanagerconf file
+* Prompt you to create additional regular and super user accounts as desired.
+
+Example run:
+```bash
+ python ./fuzzmanager_setup_helper.py 
+[+] Performing python manage.py migrate
+Operations to perform:
+  Synchronize unmigrated apps: rest_framework, chartjs
+  Apply all migrations: authtoken, sessions, admin, ec2spotmanager, auth, contenttypes, crashmanager, covmanager
+Synchronizing apps without migrations:
+  Creating tables...
+  Installing custom SQL...
+  Installing indexes...
+Running migrations:
+  Applying contenttypes.0001_initial... OK
+  Applying auth.0001_initial... OK
+  Applying admin.0001_initial... OK
+  Applying authtoken.0001_initial... OK
+  Applying crashmanager.0001_initial... OK
+  Applying crashmanager.0002_bugzillatemplate_security... OK
+  Applying crashmanager.0003_bucket_frequent... OK
+  Applying crashmanager.0004_add_tool... OK
+  Applying crashmanager.0005_add_user... OK
+  Applying crashmanager.0006_user_defaultproviderid... OK
+  Applying crashmanager.0007_bugzillatemplate_comment... OK
+  Applying crashmanager.0008_crashentry_crashaddressnumeric... OK
+  Applying crashmanager.0009_copy_crashaddress... OK
+  Applying crashmanager.0010_bugzillatemplate_security_group... OK
+  Applying crashmanager.0011_bucket_permanent... OK
+  Applying crashmanager.0012_crashentry_cachedcrashinfo... OK
+  Applying crashmanager.0013_init_cachedcrashinfo... OK
+  Applying crashmanager.0014_bugzillatemplate_testcase_filename... OK
+  Applying crashmanager.0015_crashentry_triagedonce... OK
+  Applying crashmanager.0016_auto_20160308_1500... OK
+  Applying crashmanager.0017_user_restricted... OK
+  Applying crashmanager.0018_auto_20170620_1503... OK
+  Applying covmanager.0001_initial... OK
+  Applying ec2spotmanager.0001_initial... OK
+  Applying ec2spotmanager.0002_instancestatusentry_poolstatusentry... OK
+  Applying ec2spotmanager.0003_auto_20150505_1225... OK
+  Applying ec2spotmanager.0004_auto_20150507_1311... OK
+  Applying ec2spotmanager.0005_auto_20150520_1517... OK
+  Applying ec2spotmanager.0006_auto_20150625_2050... OK
+  Applying sessions.0001_initial... OK
+
+[+] Creating fuzzmanager user account.
+[+] Super user fuzzmanager created
+[+] Obtaining auth token for fuzzmanager
+[+] Creating .fuzzmanagerconf
+Enter the the path to store fuzzmanager signatures. /home/example/signatures would be a good choice.
+/home/example/signatures
+Enter the IP Address for the fuzzmanager host or to accept 127.0.0.1, press ENTER
+
+Enter the TCP port for fuzzmanager or to accept 8000, press ENTER
+
+Type https to use https protocol or to accept http, press ENTER
+
+[Main]
+sigdir = /home/example/signatures
+serverhost = 127.0.0.1
+serverport = 8000
+serverproto = http
+serverauthtoken = 4a253efa90f514bd89ae9a86d1dc264aa3133945
+tool = jsfunfuzz
+
+[+] The fuzzmanager account password has been set to the auth_token 4a253efa90f514bd89ae9a86d1dc264aa3133945
+Adding password for user fuzzmanager
+
+[+] .htpasswd created for apache basic authentication with the fuzzmanager user password set to 81bd6220b2d7b038781010d1a463c6f0470e31e1
+Update the AuthUserFile path/to/.htpasswd line as shown in examples/apache2/default.vhost to point to this file
+Please enter a user account to create, or ENTER to quit
+
+```

--- a/server/contrib/create_user.py
+++ b/server/contrib/create_user.py
@@ -1,15 +1,15 @@
-#!/usr/bin/env python
+from __future__ import print_function
 
-import os
-import sys
 import argparse
+import os
 import random
 import string
+import sys
+
 import django
 
 
-def main(arguments):
-
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--username', dest='username', type=str, required=True)
     parser.add_argument('--email', dest='email', type=str, required=True)
@@ -26,7 +26,7 @@ def main(arguments):
     username = args.username
     email = args.email
     password = ''.join(random.sample(string.letters, 20)) if args.password is None else args.password
-    superuser = args.superuser 
+    superuser = args.superuser
 
     try:
         user_obj = User.objects.get(username=args.username)
@@ -38,8 +38,8 @@ def main(arguments):
         else:
             User.objects.create_user(username, email, password)
 
-    print password
+    print('Password: {}'.format(password))
 
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main())

--- a/server/contrib/create_user.py
+++ b/server/contrib/create_user.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import argparse
+import random
+import string
+import django
+
+
+def main(arguments):
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--username', dest='username', type=str, required=True)
+    parser.add_argument('--email', dest='email', type=str, required=True)
+    parser.add_argument('--password', dest='password', type=str, required=False)
+    parser.add_argument('--superuser', dest='superuser', action='store_true', required=False)
+
+    args = parser.parse_args()
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.settings")
+
+    from django.contrib.auth.models import User
+    django.setup()
+
+    username = args.username
+    email = args.email
+    password = ''.join(random.sample(string.letters, 20)) if args.password is None else args.password
+    superuser = args.superuser 
+
+    try:
+        user_obj = User.objects.get(username=args.username)
+        user_obj.set_password(password)
+        user_obj.save()
+    except User.DoesNotExist:
+        if superuser:
+            User.objects.create_superuser(username, email, password)
+        else:
+            User.objects.create_user(username, email, password)
+
+    print password
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/server/contrib/fuzzmanager_setup_helper.py
+++ b/server/contrib/fuzzmanager_setup_helper.py
@@ -1,28 +1,30 @@
-#!/usr/bin/env python
+from __future__ import print_function
 
 import os
-import sys
 import random
 import string
-import django
 import subprocess
+import sys
+
+import django
 
 
 def create_fuzzmanager():
     # This is a throw away password, that is soon reset to the auth_token for fuzzmanager
     password = ''.join(random.sample(string.letters, 20))
-    print '[+] Creating fuzzmanager user account.'
+    print('[+] Creating fuzzmanager user account.')
     from django.contrib.auth.models import User
 
     User.objects.create_superuser('fuzzmanager', 'fuzzmanager@example.com', password)
     try:
-        print '[+] Super user fuzzmanager created'
-        print '[+] Obtaining auth token for fuzzmanager'
-        auth_token = subprocess.check_output(['python', 'manage.py', 'get_auth_token', 'fuzzmanager']) 
+        print('[+] Super user fuzzmanager created')
+        print('[+] Obtaining auth token for fuzzmanager')
+        auth_token = subprocess.check_output(['python', 'manage.py', 'get_auth_token', 'fuzzmanager'])
         auth_token = auth_token.strip()
-        print '[+] Creating .fuzzmanagerconf'
+        print('[+] Creating .fuzzmanagerconf')
         home = os.path.expanduser('~')
-        sigdir = raw_input('Enter the the path to store fuzzmanager signatures. {}/signatures would be a good choice.\n'.format(home))
+        sigdir = raw_input(
+            'Enter the the path to store fuzzmanager signatures. {}/signatures would be a good choice.\n'.format(home))
         serverhost = raw_input('Enter the IP Address for the fuzzmanager host or to accept 127.0.0.1, press ENTER\n')
         if not serverhost:
             serverhost = '127.0.0.1'
@@ -33,7 +35,7 @@ def create_fuzzmanager():
         if not serverproto:
             serverproto = 'http'
 
-        with open('.fuzzmanagerconf','w') as f:
+        with open('.fuzzmanagerconf', 'w') as f:
             f.write('[Main]\n')
             f.write('sigdir = {}\n'.format(sigdir))
             f.write('serverhost = {}\n'.format(serverhost))
@@ -42,23 +44,22 @@ def create_fuzzmanager():
             f.write('serverauthtoken = {}\n'.format(auth_token))
             f.write('tool = jsfunfuzz\n')
 
-        with open('.fuzzmanagerconf','r') as f:
-            print f.read()
+        with open('.fuzzmanagerconf', 'r') as f:
+            print(f.read())
 
         user_obj = User.objects.get(username='fuzzmanager')
         user_obj.set_password(auth_token)
         user_obj.save()
-        print '[+] The fuzzmanager account password has been set to the auth_token {}'.format(auth_token)
+        print('[+] The fuzzmanager account password has been set to the auth_token {}'.format(auth_token))
         output = subprocess.check_output(['htpasswd', '-cb', '.htpasswd', 'fuzzmanager', auth_token])
-        print output
-        print '[+] .htpasswd created for apache basic authentication with the fuzzmanager user password set to {}'.format(auth_token)
-        print 'Update the AuthUserFile path/to/.htpasswd line as shown in examples/apache2/default.vhost to point to this file'   
+        print(output)
+        print('[+] .htpasswd created for apache basic authentication with the fuzzmanager user password set to {}'.format(auth_token))
+        print('Update the AuthUserFile path/to/.htpasswd line as shown in examples/apache2/default.vhost to point to this file')
     except User.DoesNotExist:
-            print 'Something went wrong creating the fuzzmanager account'
+        print('Something went wrong creating the fuzzmanager account')
 
 
-def main(arguments):
-
+def main():
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.settings")
     from django.contrib.auth.models import User
 
@@ -67,13 +68,12 @@ def main(arguments):
     try:
         user_obj = User.objects.get(username='fuzzmanager')
     except django.db.utils.OperationalError:
-        print '[+] Performing python manage.py migrate'
-        output = subprocess.check_output(['python', 'manage.py', 'migrate']);
-        print output
+        print('[+] Performing python manage.py migrate')
+        output = subprocess.check_output(['python', 'manage.py', 'migrate'])
+        print(output)
         create_fuzzmanager()
     except User.DoesNotExist:
         create_fuzzmanager()
-            
 
     while True:
         username = raw_input('Please enter a user account to create, or ENTER to quit\n')
@@ -99,8 +99,8 @@ def main(arguments):
                 User.objects.create_user(username, email, password)
 
         output = subprocess.check_output(['htpasswd', '-b', '.htpasswd', username, password])
-        print output
-        
- 
+        print(output)
+
+
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main())

--- a/server/contrib/fuzzmanager_setup_helper.py
+++ b/server/contrib/fuzzmanager_setup_helper.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import random
+import string
+import django
+import subprocess
+
+
+def create_fuzzmanager():
+    # This is a throw away password, that is soon reset to the auth_token for fuzzmanager
+    password = ''.join(random.sample(string.letters, 20))
+    print '[+] Creating fuzzmanager user account.'
+    from django.contrib.auth.models import User
+
+    User.objects.create_superuser('fuzzmanager', 'fuzzmanager@example.com', password)
+    try:
+        print '[+] Super user fuzzmanager created'
+        print '[+] Obtaining auth token for fuzzmanager'
+        auth_token = subprocess.check_output(['python', 'manage.py', 'get_auth_token', 'fuzzmanager']) 
+        auth_token = auth_token.strip()
+        print '[+] Creating .fuzzmanagerconf'
+        home = os.path.expanduser('~')
+        sigdir = raw_input('Enter the the path to store fuzzmanager signatures. {}/signatures would be a good choice.\n'.format(home))
+        serverhost = raw_input('Enter the IP Address for the fuzzmanager host or to accept 127.0.0.1, press ENTER\n')
+        if not serverhost:
+            serverhost = '127.0.0.1'
+        serverport = raw_input('Enter the TCP port for fuzzmanager or to accept 8000, press ENTER\n')
+        if not serverport:
+            serverport = '8000'
+        serverproto = raw_input('Type https to use https protocol or to accept http, press ENTER\n')
+        if not serverproto:
+            serverproto = 'http'
+
+        with open('.fuzzmanagerconf','w') as f:
+            f.write('[Main]\n')
+            f.write('sigdir = {}\n'.format(sigdir))
+            f.write('serverhost = {}\n'.format(serverhost))
+            f.write('serverport = {}\n'.format(serverport))
+            f.write('serverproto = {}\n'.format(serverproto))
+            f.write('serverauthtoken = {}\n'.format(auth_token))
+            f.write('tool = jsfunfuzz\n')
+
+        with open('.fuzzmanagerconf','r') as f:
+            print f.read()
+
+        user_obj = User.objects.get(username='fuzzmanager')
+        user_obj.set_password(auth_token)
+        user_obj.save()
+        print '[+] The fuzzmanager account password has been set to the auth_token {}'.format(auth_token)
+        output = subprocess.check_output(['htpasswd', '-cb', '.htpasswd', 'fuzzmanager', auth_token])
+        print output
+        print '[+] .htpasswd created for apache basic authentication with the fuzzmanager user password set to {}'.format(auth_token)
+        print 'Update the AuthUserFile path/to/.htpasswd line as shown in examples/apache2/default.vhost to point to this file'   
+    except User.DoesNotExist:
+            print 'Something went wrong creating the fuzzmanager account'
+
+
+def main(arguments):
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.settings")
+    from django.contrib.auth.models import User
+
+    django.setup()
+
+    try:
+        user_obj = User.objects.get(username='fuzzmanager')
+    except django.db.utils.OperationalError:
+        print '[+] Performing python manage.py migrate'
+        output = subprocess.check_output(['python', 'manage.py', 'migrate']);
+        print output
+        create_fuzzmanager()
+    except User.DoesNotExist:
+        create_fuzzmanager()
+            
+
+    while True:
+        username = raw_input('Please enter a user account to create, or ENTER to quit\n')
+        if not username:
+            break
+        password = raw_input('Please enter a password for {}\n'.format(username))
+        email = raw_input('Please enter an email address for {}\n'.format(username))
+        su = raw_input('Is {} a super user account? (y/n)'.format(username))
+
+        if su == 'y':
+            superuser = True
+        else:
+            superuser = False
+
+        try:
+            user_obj = User.objects.get(username=username)
+            user_obj.set_password(password)
+            user_obj.save()
+        except User.DoesNotExist:
+            if superuser:
+                User.objects.create_superuser(username, email, password)
+            else:
+                User.objects.create_user(username, email, password)
+
+        output = subprocess.check_output(['htpasswd', '-b', '.htpasswd', username, password])
+        print output
+        
+ 
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/server/files/README
+++ b/server/files/README
@@ -1,0 +1,1 @@
+placeholder for signatures directory.


### PR DESCRIPTION
syncdb was removed. When pip install -r server/requirements.txt is performed, the current README.md instructions are invalid due to Django
framework upgrade.

server/files directory didn't exist by default which would caus crontab
jobs as written in the README.md to fail, files/README is put in place
so the directory can be committed.
added server/contrib which contains helper scripts to ease in the setup
process.
replaced python ./manage syncdb with python ./manage.py migrage