### PR TITLE
Optimize __handleSignaturePost for large buckets.

### DIFF
--- a/server/crashmanager/templates/signatures/edit.html
+++ b/server/crashmanager/templates/signatures/edit.html
@@ -6,8 +6,8 @@
     <div class="panel-body">
         {% if error_message %}<div class="alert alert-warning" role="alert">{{ error_message }}</div>{% endif %}
 
-        {% if inList %}<p>New issues that will be assigned to this bucket (<a href="#crashes_in">list</a>): <span class="badge">{{ inList|length }}</span></p>{% endif %}
-        {% if outList %}<p>Issues that will be removed from this bucket (<a href="#crashes_out">list</a>): <span class="badge">{{ outList|length }}</span></p>{% endif %}
+        {% if inList %}<p>New issues that will be assigned to this bucket (<a href="#crashes_in">list</a>): <span class="badge">{{ inListCount }}</span></p>{% endif %}
+        {% if outList %}<p>Issues that will be removed from this bucket (<a href="#crashes_out">list</a>): <span class="badge">{{ outListCount }}</span></p>{% endif %}
 
         {% if bucket.pk != None %}
             <form action="{% url 'crashmanager:sigedit' bucket.pk %}" method="post">
@@ -38,13 +38,13 @@
 
         <div class="field">
             {% if inList %}
-                <label id="crashes_in">New issues that will be assigned to this bucket:</label>
-	        {% include "signatures/include/crashentry_list.html" with entries=inList %}
+                <label id="crashes_in">New issues that will be assigned to this bucket{% if inListCount > inList|length %} (truncated){% endif %}:</label>
+                {% include "signatures/include/crashentry_list.html" with entries=inList %}
             {% endif %}
 
             {% if outList %}
-                <label id="crashes_out">Issues that will be removed from this bucket:</label>
-	        {% include "signatures/include/crashentry_list.html" with entries=outList %}
+                <label id="crashes_out">Issues that will be removed from this bucket{% if outListCount > outList|length %} (truncated){% endif %}:</label>
+                {% include "signatures/include/crashentry_list.html" with entries=outList %}
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
- If saving changes, track pk only and not the whole instance.
- If previewing changes, limit each list (add/remove) to 100 entries
  max, indicating that the list is truncated, and giving the full count.
  This could maybe be paginated, but that seems like more effort than
  it's worth.
- Add tests for these cases.