### PR TITLE
Sort by id rather than created. These should be equivalent for sorting

### DIFF
--- a/server/crashmanager/views.py
+++ b/server/crashmanager/views.py
@@ -626,7 +626,7 @@ def viewSignature(request, sigid):
 
     check_authorized_for_signature(request, bucket)
 
-    entries = CrashEntry.objects.filter(bucket=sigid).filter(testcase__quality=bucket.quality).order_by('testcase__size', '-created')
+    entries = CrashEntry.objects.filter(bucket=sigid).filter(testcase__quality=bucket.quality).order_by('testcase__size', '-id')
     entries = filter_crash_entries_by_toolfilter(request, entries, restricted_only=True)
 
     bucket.bestEntry = None


### PR DESCRIPTION
order, but sorting by date is much more expensive than by primary key.