### PR TITLE
Add query parameter to defer raw fields in REST crashes view

### DIFF
--- a/server/crashmanager/serializers.py
+++ b/server/crashmanager/serializers.py
@@ -29,6 +29,16 @@ class CrashEntrySerializer(serializers.ModelSerializer):
     testcase_quality = serializers.IntegerField(source='testcase.quality', required=False, default=0)
     testcase_isbinary = serializers.BooleanField(source='testcase.isBinary', required=False, default=False)
 
+    def __init__(self, *args, **kwargs):
+
+        include_raw = kwargs.pop('include_raw', True)
+
+        super(CrashEntrySerializer, self).__init__(*args, **kwargs)
+
+        if not include_raw:
+            for field_name in ('rawCrashData', 'rawStdout', 'rawStderr'):
+                self.fields.pop(field_name)
+
     class Meta:
         model = CrashEntry
         fields = (


### PR DESCRIPTION
The param is ?include_raw=0 (defaults to 1 if not specified).

I tested with django-debug-toolbar to check that the fields are excluded from the database query properly.