### PR TITLE
Rust panics include 5-6 frames of panic internals in the backtrace

### DIFF
--- a/server/crashmanager/views.py
+++ b/server/crashmanager/views.py
@@ -609,6 +609,12 @@ def newSignature(request):
 
             if 'stackframes' in request.GET:
                 maxStackFrames = int(request.GET['stackframes'])
+            elif set(crashInfo.backtrace) & {
+                    "std::panicking::rust_panic",
+                    "std::panicking::rust_panic_with_hook",
+            }:
+                # rust panic adds 5-6 frames of noise at the top of the stack
+                maxStackFrames += 6
 
             if 'forcecrashaddress' in request.GET:
                 forceCrashAddress = bool(int(request.GET['forcecrashaddress']))


### PR DESCRIPTION
... which occupies the majority of the generated stackFrames symptom.
Try to remove this off the top if we can.