### PR TITLE
Use celery periodic tasks in crashmanager

### DIFF
--- a/examples/systemd/fuzzmanager-celerybeat.service
+++ b/examples/systemd/fuzzmanager-celerybeat.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=FuzzManager celerybeat
+After=rabbitmq-server.service
+
+[Service]
+User=ubuntu
+SyslogIdentifier=fm-celerybeat
+ExecStart=/usr/local/bin/celery --app celeryconf --loglevel INFO beat
+WorkingDirectory=/path/to/FuzzManager/server
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/systemd/fuzzmanager-celeryd-cron.service
+++ b/examples/systemd/fuzzmanager-celeryd-cron.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=FuzzManager cron celeryd
+After=rabbitmq-server.service
+
+[Service]
+User=ubuntu
+SyslogIdentifier=fm-celery-cron
+ExecStart=/usr/local/bin/celery --app celeryconf --loglevel INFO --hostname cron@%h --queues cron worker
+WorkingDirectory=/path/to/FuzzManager/server
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/systemd/fuzzmanager-celeryd.service
+++ b/examples/systemd/fuzzmanager-celeryd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=FuzzManager default celeryd
+After=rabbitmq-server.service
+
+[Service]
+User=ubuntu
+SyslogIdentifier=fm-celery-worker
+ExecStart=/usr/local/bin/celery --app celeryconf --loglevel INFO --hostname worker@%h --queues celery worker
+WorkingDirectory=/path/to/FuzzManager/server
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/upstart/celerybeat.conf
+++ b/examples/upstart/celerybeat.conf
@@ -1,0 +1,14 @@
+description "FuzzManager celerybeat"
+start on runlevel [2345]
+stop on runlevel [06]
+
+post-stop exec sleep 5
+
+setuid ubuntu
+setgid ubuntu
+
+chdir /path/to/FuzzManager/server
+
+respawn
+
+exec celery --app celeryconf --loglevel INFO beat

--- a/examples/upstart/celeryd-cron.conf
+++ b/examples/upstart/celeryd-cron.conf
@@ -1,0 +1,14 @@
+description "FuzzManager cron celeryd"
+start on runlevel [2345]
+stop on runlevel [06]
+
+post-stop exec sleep 5
+
+setuid ubuntu
+setgid ubuntu
+
+chdir /path/to/FuzzManager/server
+
+respawn
+
+exec celery --app celeryconf --loglevel INFO --concurrency 4 --hostname cron@%h --queues cron worker

--- a/examples/upstart/celeryd.conf
+++ b/examples/upstart/celeryd.conf
@@ -1,0 +1,14 @@
+description "FuzzManager default celeryd"
+start on runlevel [2345]
+stop on runlevel [06]
+
+post-stop exec sleep 5
+
+setuid ubuntu
+setgid ubuntu
+
+chdir /path/to/FuzzManager/server
+
+respawn
+
+exec celery --app celeryconf --loglevel INFO --hostname worker@%h --queues celery worker

--- a/server/celery.sh
+++ b/server/celery.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -ex
 
-celery -A celeryconf -l debug beat &
+celery -A celeryconf -l info beat &
 celery -A celeryconf -l info -c 4 -n cron@%h -Q cron worker &
 celery -A celeryconf -l info -n worker@%h -Q celery worker

--- a/server/celery.sh
+++ b/server/celery.sh
@@ -1,3 +1,5 @@
-#!/bin/sh
+#!/bin/sh -ex
 
-celery -A celeryconf -l info worker
+celery -A celeryconf -l debug beat &
+celery -A celeryconf -l info -c 4 -n cron@%h -Q cron worker &
+celery -A celeryconf -l info -n worker@%h -Q celery worker

--- a/server/celeryconf.py
+++ b/server/celeryconf.py
@@ -7,5 +7,5 @@ import os
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'server.settings_nondebug')
 
-app = Celery('tasks', broker='amqp://guest@localhost//')
+app = Celery('tasks', broker='amqp://')
 app.config_from_object(settings)

--- a/server/crashmanager/cron.py
+++ b/server/crashmanager/cron.py
@@ -1,0 +1,31 @@
+import os
+import shutil
+from tempfile import mkstemp
+
+from django.core.management import call_command
+
+from celeryconf import app
+
+SIGNATURES_ZIP = os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir, 'files', 'signatures.zip'))
+
+@app.task
+def bug_update_status():
+    call_command('bug_update_status')
+
+@app.task
+def cleanup_old_crashes():
+    call_command('cleanup_old_crashes')
+
+@app.task
+def triage_new_crashes():
+    call_command('triage_new_crashes')
+
+@app.task
+def export_signatures():
+    fd, tmpf = mkstemp(prefix="fm-sigs-", suffix=".zip")
+    os.close(fd)
+    try:
+        call_command('export_signatures', tmpf)
+        shutil.copy(tmpf, SIGNATURES_ZIP)
+    finally:
+        os.unlink(tmpf)

--- a/server/crashmanager/management/commands/export_signatures.py
+++ b/server/crashmanager/management/commands/export_signatures.py
@@ -1,7 +1,6 @@
 import json
 import os
 import shutil
-from tempfile import mkdtemp
 from zipfile import ZipFile
 
 from django.core.management.base import BaseCommand
@@ -20,39 +19,26 @@ class Command(BaseCommand):
     @mgmt_lock_required
     def handle(self, filename, **options):
 
-        tmpDir = mkdtemp(prefix="fuzzmanager-sigexport")
+        with ZipFile(filename, 'w') as zipFile:
+            for bucket in Bucket.objects.annotate(size=Count('crashentry'), quality=Min('crashentry__testcase__quality')):
+                try:
+                    bucket.bestEntry = CrashEntry.objects.filter(bucket=bucket.pk).filter(testcase__quality=bucket.quality).order_by('testcase__size', '-created')[0]
+                except IndexError:
+                    bucket.bestEntry = None
 
-        try:
-            with ZipFile(filename, 'w') as zipFile:
-                for bucket in Bucket.objects.annotate(size=Count('crashentry'), quality=Min('crashentry__testcase__quality')):
-                    try:
-                        bucket.bestEntry = CrashEntry.objects.filter(bucket=bucket.pk).filter(testcase__quality=bucket.quality).order_by('testcase__size', '-created')[0]
-                    except IndexError:
-                        bucket.bestEntry = None
+                metadata = {}
+                metadata['size'] = bucket.size
+                metadata['shortDescription'] = bucket.shortDescription
+                metadata['frequent'] = bucket.frequent
+                if bucket.bug is not None:
+                    metadata['bug__id'] = bucket.bug.externalId
 
-                    metadata = {}
-                    metadata['size'] = bucket.size
-                    metadata['shortDescription'] = bucket.shortDescription
-                    metadata['frequent'] = bucket.frequent
-                    if bucket.bug is not None:
-                        metadata['bug__id'] = bucket.bug.externalId
+                if bucket.bestEntry is not None and bucket.bestEntry.testcase is not None:
+                    metadata['testcase__quality'] = bucket.bestEntry.testcase.quality
+                    metadata['testcase__size'] = bucket.bestEntry.testcase.size
 
-                    if bucket.bestEntry is not None and bucket.bestEntry.testcase is not None:
-                        metadata['testcase__quality'] = bucket.bestEntry.testcase.quality
-                        metadata['testcase__size'] = bucket.bestEntry.testcase.size
+                sigFileName = "%d.signature" % bucket.pk
+                metaFileName = "%d.metadata" % bucket.pk
 
-                    sigFileName = "%d.signature" % bucket.pk
-                    metaFileName = "%d.metadata" % bucket.pk
-                    sigFile = os.path.join(tmpDir, sigFileName)
-                    metaFile = os.path.join(tmpDir, metaFileName)
-
-                    with open(sigFile, 'w') as f:
-                        f.write(bucket.signature)
-
-                    with open(metaFile, 'w') as f:
-                        f.write(json.dumps(metadata, indent=4))
-
-                    zipFile.write(sigFile, sigFileName)
-                    zipFile.write(metaFile, metaFileName)
-        finally:
-            shutil.rmtree(tmpDir)
+                zipFile.writestr(sigFileName, bucket.signature)
+                zipFile.writestr(metaFileName, json.dumps(metadata, indent=4))

--- a/server/crashmanager/tasks.py
+++ b/server/crashmanager/tasks.py
@@ -1,14 +1,11 @@
 from collections import OrderedDict
-from django.conf import settings
 import os
 import sys
 
-# Add the server basedir to PYTHONPATH so Celery on the command line
-# can find the Django settings imports and packages properly
-BASE_DIR = os.path.dirname(os.path.realpath(__file__))
-sys.path += [os.path.abspath(os.path.join(BASE_DIR, ".."))]
+from django.conf import settings
 
 from celeryconf import app
+from . import cron  # ensure cron tasks get registered
 
 # This is a per-worker global cache mapping short descriptions of
 # crashes to a list of bucket candidates to try first.
@@ -16,8 +13,7 @@ triage_cache = OrderedDict()
 
 @app.task
 def triage_new_crash(pk):
-    global triage_cache
-    from crashmanager.models import CrashEntry, Bucket
+    from .models import CrashEntry, Bucket
     entry = CrashEntry.objects.get(pk=pk)
     crashInfo = entry.getCrashInfo(attachTestcase=True)
 

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -236,3 +236,18 @@ USERDATA_STORAGE = os.path.join(BASE_DIR)
 # CELERY_TASK_SERIALIZER = 'json'
 # CELERY_RESULT_SERIALIZER = 'json'
 # CELERY_TRIAGE_MEMCACHE_ENTRIES = 100
+# CELERY_TASK_ROUTES = {"crashmanager.cron.*": {"queue": "cron"}}
+# CELERYBEAT_SCHEDULE = {
+#     'Poll Bugzilla every 15 minutes': {
+#         'task': 'crashmanager.cron.bug_update_status',
+#         'schedule': 15 * 60,
+#     },
+#     'Cleanup CrashEntry/Bucket objects every 30 minutes': {
+#         'task': 'crashmanager.cron.cleanup_old_crashes',
+#         'schedule': 30 * 60,
+#     },
+#     'Create signatures.zip hourly': {
+#         'task': 'crashmanager.cron.export_signatures',
+#         'schedule': 60 * 60,
+#     },
+# }


### PR DESCRIPTION
This runs management commands of crashmanager using celery periodic tasks. A separate queue is used to avoid delaying tasks under heavy triage workloads, and to prevent long-running tasks from affecting
triage.

`server/celery.sh` can be used to launch, or upstart/systemd example configs are provided.