### PR TITLE
Second wave of flake8 linter changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
     - pip install -r server/requirements.txt
     - pip install --upgrade codecov pytest-flake8 pytest-pylint pytest-cov pytest-django pytest-pythonpath
 script:
-    - python -m pytest -v --cov=. --cov-report term-missing
+    - python -m pytest --flake8 -v --cov=. --cov-report term-missing
 after_success:
     - codecov -X gcov
 deploy:

--- a/Collector/Collector.py
+++ b/Collector/Collector.py
@@ -25,7 +25,6 @@ import base64
 import hashlib
 import json
 import os
-import platform
 import requests
 import shutil
 import sys
@@ -38,11 +37,11 @@ FTB_PATH = os.path.abspath(os.path.join(BASE_DIR, ".."))
 sys.path += [FTB_PATH]
 
 from FTB.ConfigurationFiles import ConfigurationFiles
-from FTB.ProgramConfiguration import ProgramConfiguration
-from FTB.Running.AutoRunner import AutoRunner
-from FTB.Signatures.CrashInfo import CrashInfo
-from FTB.Signatures.CrashSignature import CrashSignature
-from Reporter.Reporter import Reporter, signature_checks, remote_checks
+from FTB.ProgramConfiguration import ProgramConfiguration  # noqa
+from FTB.Running.AutoRunner import AutoRunner  # noqa
+from FTB.Signatures.CrashInfo import CrashInfo  # noqa
+from FTB.Signatures.CrashSignature import CrashSignature  # noqa
+from Reporter.Reporter import Reporter, signature_checks, remote_checks  # noqa
 
 __all__ = []
 __version__ = 0.1

--- a/Collector/Collector.py
+++ b/Collector/Collector.py
@@ -36,7 +36,6 @@ BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 FTB_PATH = os.path.abspath(os.path.join(BASE_DIR, ".."))
 sys.path += [FTB_PATH]
 
-from FTB.ConfigurationFiles import ConfigurationFiles
 from FTB.ProgramConfiguration import ProgramConfiguration  # noqa
 from FTB.Running.AutoRunner import AutoRunner  # noqa
 from FTB.Signatures.CrashInfo import CrashInfo  # noqa

--- a/Collector/test_Collector.py
+++ b/Collector/test_Collector.py
@@ -25,7 +25,6 @@ import requests
 from Collector.Collector import Collector, main
 from FTB.Signatures.CrashInfo import CrashInfo
 from FTB.ProgramConfiguration import ProgramConfiguration
-from FTB.Signatures.CrashSignature import CrashSignature
 from crashmanager.models import CrashEntry
 
 if sys.version_info.major == 3:

--- a/Collector/test_Collector.py
+++ b/Collector/test_Collector.py
@@ -229,7 +229,7 @@ def test_collector_refresh(tmpdir, monkeypatch, capsys):
     # check that 404 raises
     monkeypatch.undo()
 
-    class response_t(object):
+    class response_t(object):  # noqa
         status_code = requests.codes["not found"]
         text = "Not found"
 
@@ -242,7 +242,7 @@ def test_collector_refresh(tmpdir, monkeypatch, capsys):
     # check that bad zips raise errors
     monkeypatch.undo()
     with open(tmpdir.join('sigs', 'other.txt').strpath, 'rb') as fp:
-        class response_t(object):
+        class response_t(object):  # noqa
             status_code = requests.codes["ok"]
             text = "OK"
             raw = fp
@@ -258,7 +258,7 @@ def test_collector_refresh(tmpdir, monkeypatch, capsys):
         fp.seek(0x42)
         fp.write(b'\xFF')
     with open(tmpdir.join('out.zip').strpath, 'rb') as fp:
-        class response_t(object):
+        class response_t(object):  # noqa
             status_code = requests.codes["ok"]
             text = "OK"
             raw = fp
@@ -366,7 +366,7 @@ def test_collector_download(tmpdir, monkeypatch):
         collector.download(123)
 
     # download with no testcase
-    class response1_t(object):
+    class response1_t(object):  # noqa
         status_code = requests.codes["ok"]
         text = 'OK'
 
@@ -378,7 +378,7 @@ def test_collector_download(tmpdir, monkeypatch):
     assert result is None
 
     # invalid REST response
-    class response1_t(object):
+    class response1_t(object):  # noqa
         status_code = requests.codes["ok"]
         text = 'OK'
 
@@ -390,7 +390,7 @@ def test_collector_download(tmpdir, monkeypatch):
         collector.download(123)
 
     # REST query returns http error
-    class response1_t(object):
+    class response1_t(object):  # noqa
         status_code = 404
         text = 'Not found'
     monkeypatch.undo()

--- a/Collector/test_Collector.py
+++ b/Collector/test_Collector.py
@@ -18,10 +18,6 @@ import platform
 import sys
 import time
 import zipfile
-if sys.version_info.major == 3:
-    from urllib.parse import urlsplit
-else:
-    from urlparse import urlsplit
 
 import pytest
 import requests
@@ -32,6 +28,11 @@ from FTB.Signatures.CrashInfo import CrashInfo
 from FTB.ProgramConfiguration import ProgramConfiguration
 from FTB.Signatures.CrashSignature import CrashSignature
 from crashmanager.models import CrashEntry
+
+if sys.version_info.major == 3:
+    from urllib.parse import urlsplit
+else:
+    from urlparse import urlsplit
 
 asanTraceCrash = '''ASAN:SIGSEGV
 =================================================================

--- a/Collector/test_Collector.py
+++ b/Collector/test_Collector.py
@@ -21,7 +21,6 @@ import zipfile
 
 import pytest
 import requests
-from requests.exceptions import ConnectionError
 
 from Collector.Collector import Collector, main
 from FTB.Signatures.CrashInfo import CrashInfo

--- a/CovReporter/CovReporter.py
+++ b/CovReporter/CovReporter.py
@@ -164,7 +164,7 @@ class CovReporter(Reporter):
                 # Walk the tree down, one path part at a time and create parts
                 # on the fly if they don't exist yet in our tree.
                 for path_part in path_parts:
-                    if not path_part in ptr:
+                    if path_part not in ptr:
                         ptr[path_part] = {"children": {}}
 
                     ptr = ptr[path_part]["children"]

--- a/CovReporter/CovReporter.py
+++ b/CovReporter/CovReporter.py
@@ -30,7 +30,7 @@ BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 FTB_PATH = os.path.abspath(os.path.join(BASE_DIR, ".."))
 sys.path += [FTB_PATH]
 
-from Reporter.Reporter import remote_checks, Reporter
+from Reporter.Reporter import remote_checks, Reporter  # noqa
 
 __all__ = []
 __version__ = 0.1

--- a/CovReporter/test_CovReporter.py
+++ b/CovReporter/test_CovReporter.py
@@ -13,7 +13,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 '''
 
 import json
-import os
 import unittest
 
 from CovReporter import CovReporter

--- a/EC2Reporter/EC2Reporter.py
+++ b/EC2Reporter/EC2Reporter.py
@@ -24,7 +24,6 @@ import argparse
 from fasteners import InterProcessLock
 import functools
 import os
-import platform
 import random
 import requests
 import sys

--- a/EC2Reporter/EC2Reporter.py
+++ b/EC2Reporter/EC2Reporter.py
@@ -33,8 +33,8 @@ BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 FTB_PATH = os.path.abspath(os.path.join(BASE_DIR, ".."))
 sys.path += [FTB_PATH]
 
-from FTB.ConfigurationFiles import ConfigurationFiles
-from Reporter.Reporter import Reporter, remote_checks
+from FTB.ConfigurationFiles import ConfigurationFiles  # noqa
+from Reporter.Reporter import Reporter, remote_checks  # noqa
 
 __all__ = []
 __version__ = 0.1

--- a/FTB/AssertionHelper.py
+++ b/FTB/AssertionHelper.py
@@ -129,7 +129,7 @@ def getAuxiliaryAbortMessage(output):
         line = re.sub("^\\[\\d+\\]\\s+", "", line, count=1)
 
         if "ERROR: AddressSanitizer" in line:
-            if not "SEGV on unknown address" in line:
+            if "SEGV on unknown address" not in line:
                 # Strip address, registers and PID prefix
                 line = re.sub(r"on address 0x[0-9a-f]+", "", line)
                 line = re.sub(r"(at |\()pc 0x[0-9a-f]+", "", line)

--- a/FTB/AssertionHelper.py
+++ b/FTB/AssertionHelper.py
@@ -165,7 +165,7 @@ def getSanitizedAssertionPattern(msgs):
     @rtype: string
     @return: Sanitized assertion message (regular expression)
     '''
-    assert msgs != None
+    assert msgs is not None
 
     returnList = True
     if not isinstance(msgs, list):

--- a/FTB/ProgramConfiguration.py
+++ b/FTB/ProgramConfiguration.py
@@ -67,7 +67,7 @@ class ProgramConfiguration():
         mainConfig = config.mainConfig
 
         for field in ["product", "platform", "os"]:
-            if not field in mainConfig:
+            if field not in mainConfig:
                 raise RuntimeError('Missing "%s" in binary configuration file %s' % (field, binaryConfig))
 
         # Version field is optional

--- a/FTB/Running/AutoRunner.py
+++ b/FTB/Running/AutoRunner.py
@@ -52,7 +52,7 @@ class AutoRunner():
             for envkey in env:
                 self.env[envkey] = env[envkey]
 
-        if not 'LD_LIBRARY_PATH' in self.env:
+        if 'LD_LIBRARY_PATH' not in self.env:
             self.env['LD_LIBRARY_PATH'] = os.path.dirname(binary)
 
         self.args = args
@@ -205,7 +205,7 @@ class ASanRunner(AutoRunner):
         self.cmdArgs.append(self.binary)
         self.cmdArgs.extend(self.args)
 
-        if not "ASAN_SYMBOLIZER_PATH" in self.env:
+        if "ASAN_SYMBOLIZER_PATH" not in self.env:
             if "ASAN_SYMBOLIZER_PATH" in os.environ:
                 self.env["ASAN_SYMBOLIZER_PATH"] = os.environ["ASAN_SYMBOLIZER_PATH"]
             else:
@@ -220,7 +220,7 @@ class ASanRunner(AutoRunner):
                 "Misconfigured ASAN_SYMBOLIZER_PATH: %s" % self.env["ASAN_SYMBOLIZER_PATH"]
             )
 
-        if not "UBSAN_OPTIONS" in self.env:
+        if "UBSAN_OPTIONS" not in self.env:
             if "UBSAN_OPTIONS" in os.environ:
                 self.env["UBSAN_OPTIONS"] = os.environ["UBSAN_OPTIONS"]
             else:
@@ -229,7 +229,7 @@ class ASanRunner(AutoRunner):
                 # to isolate a UBSan trace.
                 self.env["UBSAN_OPTIONS"] = "print_stacktrace=1"
 
-        if not "ASAN_OPTIONS" in self.env:
+        if "ASAN_OPTIONS" not in self.env:
             if "ASAN_OPTIONS" in os.environ:
                 self.env["ASAN_OPTIONS"] = os.environ["ASAN_OPTIONS"]
             else:

--- a/FTB/Running/GDB.py
+++ b/FTB/Running/GDB.py
@@ -50,5 +50,5 @@ def printImportantRegisters():
     for reg in regs:
         try:
             print(reg + "\t" + regAsHexStr(reg) + "\t" + regAsIntStr(reg))
-        except:
+        except Exception:
             print(reg + "\t" + regAsRaw(reg))

--- a/FTB/Running/GDB.py
+++ b/FTB/Running/GDB.py
@@ -16,11 +16,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
 def is64bit():
-    return not str(gdb.parse_and_eval("$rax")) == "void"  # @UndefinedVariable
+    return not str(gdb.parse_and_eval("$rax")) == "void"  # noqa @UndefinedVariable
 
 
 def isARM():
-    return not str(gdb.parse_and_eval("$r0")) == "void"  # @UndefinedVariable
+    return not str(gdb.parse_and_eval("$r0")) == "void"  # noqa @UndefinedVariable
 
 
 def regAsHexStr(reg):
@@ -28,15 +28,15 @@ def regAsHexStr(reg):
         mask = 0xffffffffffffffff
     else:
         mask = 0xffffffff
-    return "0x%x" % (int(str(gdb.parse_and_eval("$" + reg)), 0) & mask)  # @UndefinedVariable
+    return "0x%x" % (int(str(gdb.parse_and_eval("$" + reg)), 0) & mask)  # noqa @UndefinedVariable
 
 
 def regAsIntStr(reg):
-    return str(int(str(gdb.parse_and_eval("$" + reg)), 0))  # @UndefinedVariable
+    return str(int(str(gdb.parse_and_eval("$" + reg)), 0))  # noqa @UndefinedVariable
 
 
 def regAsRaw(reg):
-    return str(gdb.parse_and_eval("$" + reg))  # @UndefinedVariable
+    return str(gdb.parse_and_eval("$" + reg))  # noqa @UndefinedVariable
 
 
 def printImportantRegisters():

--- a/FTB/Running/PersistentApplication.py
+++ b/FTB/Running/PersistentApplication.py
@@ -261,14 +261,14 @@ class SimplePersistentApplication(PersistentApplication):
 
             # Assume PersistentMode.NONE and expect the process to exit now
             (maxSleepTime, pollInterval) = (self.processingTimeout, 0.2)
-            while self.process.poll() == None and maxSleepTime > 0:
+            while self.process.poll() is None and maxSleepTime > 0:
                 maxSleepTime -= pollInterval
                 time.sleep(pollInterval)
 
             ret = ApplicationStatus.OK
 
             # Process is still alive, consider this a timeout
-            if self.process.poll() == None:
+            if self.process.poll() is None:
                 ret = ApplicationStatus.TIMEDOUT
             elif self._crashed():
                 ret = ApplicationStatus.CRASHED
@@ -295,7 +295,7 @@ class SimplePersistentApplication(PersistentApplication):
             self.stderr = self.errCollector.output
 
     def runTest(self, test):
-        if self.process == None or self.process.poll() != None:
+        if self.process is None or self.process.poll() is not None:
             self.start()
 
         # Write test data and also log it
@@ -305,7 +305,7 @@ class SimplePersistentApplication(PersistentApplication):
             try:
                 response = self.responseQueue.get(block=True, timeout=self.processingTimeout)
             except Queue.Empty:
-                if self.process.poll() == None:
+                if self.process.poll() is None:
                     # The process is still running, force it to stop and return timeout code
                     self.stop()
                     return ApplicationStatus.TIMEDOUT
@@ -372,18 +372,18 @@ class SimplePersistentApplication(PersistentApplication):
 
     def _terminateProcess(self):
         if self.process:
-            if self.process.poll() == None:
+            if self.process.poll() is None:
                 # Try to terminate the process gracefully first
                 self.process.terminate()
 
                 # Emulate a wait() with timeout. Because wait() having
                 # a timeout would be way too easy, wouldn't it? -.-
                 (maxSleepTime, pollInterval) = (3, 0.2)
-                while self.process.poll() == None and maxSleepTime > 0:
+                while self.process.poll() is None and maxSleepTime > 0:
                     maxSleepTime -= pollInterval
                     time.sleep(pollInterval)
 
                 # Process is still alive, kill it and wait
-                if self.process.poll() == None:
+                if self.process.poll() is None:
                     self.process.kill()
                     self.process.wait()

--- a/FTB/Running/StreamCollector.py
+++ b/FTB/Running/StreamCollector.py
@@ -54,7 +54,7 @@ class StreamCollector(threading.Thread):
                 self.output.append(line)
 
                 # With maxBacklog specified, emulate a FIFO with the given length
-                if self.maxBacklog != None and len(self.output) > self.maxBacklog:
+                if self.maxBacklog is not None and len(self.output) > self.maxBacklog:
                     self.output.pop(0)
 
         self.fd.close()

--- a/FTB/Signatures/CrashInfo.py
+++ b/FTB/Signatures/CrashInfo.py
@@ -243,7 +243,7 @@ class CrashInfo():
         if not abortMsg and self.rawCrashData:
             abortMsg = AssertionHelper.getAssertion(self.rawCrashData)
 
-        if abortMsg != None:
+        if abortMsg is not None:
             if isinstance(abortMsg, list):
                 return " ".join(abortMsg)
             else:
@@ -290,7 +290,7 @@ class CrashInfo():
             # only on version 1.3 or higher, because the "crashdata" source
             # type for output matching was added in that version.
             abortMsgs = AssertionHelper.getAssertion(self.rawCrashData)
-            if abortMsgs != None:
+            if abortMsgs is not None:
                 abortMsgInCrashdata = True
 
         # Still no abort message, fall back to auxiliary abort messages (ASan/UBSan)
@@ -302,10 +302,10 @@ class CrashInfo():
             # only on version 1.3 or higher, because the "crashdata" source
             # type for output matching was added in that version.
             abortMsgs = AssertionHelper.getAuxiliaryAbortMessage(self.rawCrashData)
-            if abortMsgs != None:
+            if abortMsgs is not None:
                 abortMsgInCrashdata = True
 
-        if abortMsgs != None:
+        if abortMsgs is not None:
             if not isinstance(abortMsgs, list):
                 abortMsgs = [abortMsgs]
 
@@ -369,7 +369,7 @@ class CrashInfo():
                 if str(framesArray[frameIdx]) != '?':
                     lastSymbolizedFrame = frameIdx
 
-            if lastSymbolizedFrame != None:
+            if lastSymbolizedFrame is not None:
                 # Remove all elements behind the last symbolized frame
                 framesArray = framesArray[:lastSymbolizedFrame + 1]
             else:
@@ -381,10 +381,10 @@ class CrashInfo():
                 symptomArr.append({"type": "stackFrames", "functionNames": framesArray})
 
         # Missing too much of the top stack frames, add additional crash information
-        stackIsInsufficient = topStackMissCount >= 2 and abortMsgs == None
+        stackIsInsufficient = topStackMissCount >= 2 and abortMsgs is None
 
         includeCrashAddress = stackIsInsufficient or forceCrashAddress
-        includeCrashInstruction = (stackIsInsufficient and self.crashInstruction != None) or forceCrashInstruction
+        includeCrashInstruction = (stackIsInsufficient and self.crashInstruction is not None) or forceCrashInstruction
 
         if not symptomArr and not includeCrashInstruction:
             # If at this point, we don't have any symptoms from either backtrace
@@ -409,7 +409,7 @@ class CrashInfo():
             symptomArr.append(crashAddressSymptomObj)
 
         if includeCrashInstruction:
-            if self.crashInstruction == None:
+            if self.crashInstruction is None:
                 failureReason = self.failureReason
                 self.failureReason = "No crash instruction available from crash data. Reason: %s" % failureReason
                 return None
@@ -472,13 +472,13 @@ class NoCrashInfo(CrashInfo):
         '''
         CrashInfo.__init__(self)
 
-        if stdout != None:
+        if stdout is not None:
             self.rawStdout.extend(stdout)
 
-        if stderr != None:
+        if stderr is not None:
             self.rawStderr.extend(stderr)
 
-        if crashData != None:
+        if crashData is not None:
             self.rawCrashData.extend(crashData)
 
         self.configuration = configuration
@@ -586,7 +586,7 @@ class ASanCrashInfo(CrashInfo):
         if not abortMsg and self.rawCrashData:
             abortMsg = AssertionHelper.getAssertion(self.rawCrashData)
 
-        if abortMsg != None:
+        if abortMsg is not None:
             if isinstance(abortMsg, list):
                 return " ".join(abortMsg)
             else:
@@ -600,7 +600,7 @@ class ASanCrashInfo(CrashInfo):
         if not abortMsg and self.rawCrashData:
             abortMsg = AssertionHelper.getAuxiliaryAbortMessage(self.rawCrashData)
 
-        if abortMsg != None:
+        if abortMsg is not None:
             rwMsg = None
             if isinstance(abortMsg, list):
                 asanMsg = abortMsg[0]
@@ -728,13 +728,13 @@ class GDBCrashInfo(CrashInfo):
         '''
         CrashInfo.__init__(self)
 
-        if stdout != None:
+        if stdout is not None:
             self.rawStdout.extend(stdout)
 
-        if stderr != None:
+        if stderr is not None:
             self.rawStderr.extend(stderr)
 
-        if crashData != None:
+        if crashData is not None:
             self.rawCrashData.extend(crashData)
 
         self.configuration = configuration
@@ -764,36 +764,36 @@ class GDBCrashInfo(CrashInfo):
             # buffer content. If we detect this constellation, then it's highly likely
             # that we have a valid trace line but no pattern that fits it. We need
             # to make sure that we report this.
-            if (not pastFrames and re.match("\\s*#\\d+.+", lastLineBuf) != None and
-                    re.match("\\s*#\\d+.+", traceLine) != None):
+            if (not pastFrames and re.match("\\s*#\\d+.+", lastLineBuf) is not None and
+                    re.match("\\s*#\\d+.+", traceLine) is not None):
                 print("Fatal error parsing this GDB trace line:", file=sys.stderr)
                 print(lastLineBuf, file=sys.stderr)
                 raise RuntimeError("Fatal error parsing GDB trace")
 
             if not len(lastLineBuf):
                 match = re.search(gdbRegisterPattern, traceLine)
-                if match != None:
+                if match is not None:
                     pastFrames = True
                     register = match.group(1)
                     value = int(match.group(2), 16)
                     self.registers[register] = value
                 else:
                     match = re.search(gdbCrashAddressPattern, traceLine)
-                    if match != None:
+                    if match is not None:
                         self.crashAddress = int(match.group(1), 16)
                     else:
                         match = re.search(gdbCrashInstructionPattern, traceLine)
-                        if match != None:
+                        if match is not None:
                             self.crashInstruction = match.group(1)
 
                             # In certain cases, the crash instruction can have
                             # trailing function information, strip it here.
                             match = re.search("(\\s+<.+>\\s*)$", self.crashInstruction)
-                            if match != None:
+                            if match is not None:
                                 self.crashInstruction = self.crashInstruction.replace(match.group(1), "")
 
             if not pastFrames:
-                if not len(lastLineBuf) and re.match("\\s*#\\d+.+", traceLine) == None:
+                if not len(lastLineBuf) and re.match("\\s*#\\d+.+", traceLine) is None:
                     # Skip additional lines
                     continue
 
@@ -804,12 +804,12 @@ class GDBCrashInfo(CrashInfo):
 
                 for gdbPattern in gdbFramePatterns:
                     match = re.search(gdbPattern, lastLineBuf)
-                    if match != None:
+                    if match is not None:
                         frameIndex = int(match.group(1))
                         functionName = match.group(3)
                         break
 
-                if frameIndex == None:
+                if frameIndex is None:
                     # Line might not be complete yet, try adding the next
                     continue
                 else:
@@ -834,12 +834,12 @@ class GDBCrashInfo(CrashInfo):
 
                 self.backtrace.append(functionName)
 
-        if self.crashInstruction != None:
+        if self.crashInstruction is not None:
             # Remove any leading/trailing whitespaces
             self.crashInstruction = self.crashInstruction.strip()
 
         # If we have no crash address but the instruction, try to calculate the crash address
-        if self.crashAddress == None and self.crashInstruction != None:
+        if self.crashAddress is None and self.crashInstruction is not None:
             crashAddress = GDBCrashInfo.calculateCrashAddress(self.crashInstruction, self.registers)
 
             if isinstance(crashAddress, (unicode_, bytes)):
@@ -848,7 +848,7 @@ class GDBCrashInfo(CrashInfo):
 
             self.crashAddress = crashAddress
 
-            if self.crashAddress != None and self.crashAddress < 0:
+            if self.crashAddress is not None and self.crashAddress < 0:
                 if RegisterHelper.getBitWidth(self.registers) == 32:
                     self.crashAddress = uint32(self.crashAddress)
                 else:
@@ -930,7 +930,7 @@ class GDBCrashInfo(CrashInfo):
 
         def calculateDerefOpAddress(derefOp):
             match = re.match("\*?((?:\\-?0x[0-9a-f]+)?)\\(%([a-z0-9]+)\\)", derefOp)
-            if match != None:
+            if match is not None:
                 offset = 0
                 if len(match.group(1)):
                     offset = int(match.group(1), 16)
@@ -938,7 +938,7 @@ class GDBCrashInfo(CrashInfo):
                 val = RegisterHelper.getRegisterValue(match.group(2), registerMap)
 
                 # If we don't have the value, return None
-                if val == None:
+                if val is None:
                     return (None, "Missing value for register %s " % match.group(2))
                 else:
                     if RegisterHelper.getBitWidth(registerMap) == 32:
@@ -989,7 +989,7 @@ class GDBCrashInfo(CrashInfo):
                     derefOp = parts[0]
 
                 if isDerefOp(parts[1]):
-                    if derefOp != None:
+                    if derefOp is not None:
                         if ":(" in parts[1]:
                             # This can be an instruction using multiple segments, like:
                             #
@@ -1017,7 +1017,7 @@ class GDBCrashInfo(CrashInfo):
 
                     derefOp = parts[1]
 
-                if derefOp != None:
+                if derefOp is not None:
                         (val, failed) = calculateDerefOpAddress(derefOp)
                         if failed:
                             failureReason = failed
@@ -1036,7 +1036,7 @@ class GDBCrashInfo(CrashInfo):
 
                     for x in (parts[1], parts[0]):
                         result = re.match("\\$?(\\-?0x[0-9a-f]+)", x)
-                        if result != None:
+                        if result is not None:
                             return int(result.group(1), 16)
             elif len(parts) == 3:
                 # Example instruction: shrb   -0x69(%rdx,%rbx,8)
@@ -1045,7 +1045,7 @@ class GDBCrashInfo(CrashInfo):
 
                     (result, reason) = GDBCrashInfo.calculateComplexDerefOpAddress(complexDerefOp, registerMap)
 
-                    if result == None:
+                    if result is None:
                         failureReason = reason
                     else:
                         return result
@@ -1059,7 +1059,7 @@ class GDBCrashInfo(CrashInfo):
 
                 (result, reason) = GDBCrashInfo.calculateComplexDerefOpAddress(complexDerefOp, registerMap)
 
-                if result == None:
+                if result is None:
                     failureReason = reason
                 else:
                     return result
@@ -1077,7 +1077,7 @@ class GDBCrashInfo(CrashInfo):
     def calculateComplexDerefOpAddress(complexDerefOp, registerMap):
 
         match = re.match("((?:\\-?0x[0-9a-f]+)?)\\(%([a-z0-9]+),%([a-z0-9]+),([0-9]+)\\)", complexDerefOp)
-        if match != None:
+        if match is not None:
             offset = 0
             if len(match.group(1)) > 0:
                 offset = int(match.group(1), 16)
@@ -1088,8 +1088,8 @@ class GDBCrashInfo(CrashInfo):
             mult = int(match.group(4), 16)
 
             # If we're missing any of the two register values, return None
-            if regA == None or regB == None:
-                if regA == None:
+            if regA is None or regB is None:
+                if regA is None:
                     return (None, "Missing value for register %s" % match.group(2))
                 else:
                     return (None, "Missing value for register %s" % match.group(3))
@@ -1111,13 +1111,13 @@ class MinidumpCrashInfo(CrashInfo):
         '''
         CrashInfo.__init__(self)
 
-        if stdout != None:
+        if stdout is not None:
             self.rawStdout.extend(stdout)
 
-        if stderr != None:
+        if stderr is not None:
             self.rawStderr.extend(stderr)
 
-        if crashData != None:
+        if crashData is not None:
             self.rawCrashData.extend(crashData)
 
         self.configuration = configuration
@@ -1130,7 +1130,7 @@ class MinidumpCrashInfo(CrashInfo):
 
         crashThread = None
         for traceLine in minidumpOuput:
-            if crashThread != None:
+            if crashThread is not None:
                 if traceLine.startswith("%s|" % crashThread):
                     components = traceLine.split("|")
 
@@ -1160,13 +1160,13 @@ class AppleCrashInfo(CrashInfo):
         '''
         CrashInfo.__init__(self)
 
-        if stdout != None:
+        if stdout is not None:
             self.rawStdout.extend(stdout)
 
-        if stderr != None:
+        if stderr is not None:
             self.rawStderr.extend(stderr)
 
-        if crashData != None:
+        if crashData is not None:
             self.rawCrashData.extend(crashData)
 
         self.configuration = configuration
@@ -1373,13 +1373,13 @@ class RustCrashInfo(CrashInfo):
         '''
         CrashInfo.__init__(self)
 
-        if stdout != None:
+        if stdout is not None:
             self.rawStdout.extend(stdout)
 
-        if stderr != None:
+        if stderr is not None:
             self.rawStderr.extend(stderr)
 
-        if crashData != None:
+        if crashData is not None:
             self.rawCrashData.extend(crashData)
 
         self.configuration = configuration

--- a/FTB/Signatures/CrashInfo.py
+++ b/FTB/Signatures/CrashInfo.py
@@ -1052,9 +1052,9 @@ class GDBCrashInfo(CrashInfo):
                 else:
                     raise RuntimeError("Unexpected instruction pattern: %s" % crashInstruction)
             elif len(parts) == 4:
-                if "(" in parts[0] and not ")" in parts[0]:
+                if "(" in parts[0] and ")" not in parts[0]:
                     complexDerefOp = parts[0] + "," + parts[1] + "," + parts[2]
-                elif not "(" in parts[0] and not ")" in parts[0]:
+                elif "(" not in parts[0] and ")" not in parts[0]:
                     complexDerefOp = parts[1] + "," + parts[2] + "," + parts[3]
 
                 (result, reason) = GDBCrashInfo.calculateComplexDerefOpAddress(complexDerefOp, registerMap)

--- a/FTB/Signatures/CrashSignature.py
+++ b/FTB/Signatures/CrashSignature.py
@@ -79,13 +79,13 @@ class CrashSignature():
         @rtype: bool
         @return: True if the signature matches, False otherwise
         '''
-        if self.platforms != None and not crashInfo.configuration.platform in self.platforms:
+        if self.platforms != None and crashInfo.configuration.platform not in self.platforms:
             return False
 
-        if self.operatingSystems != None and not crashInfo.configuration.os in self.operatingSystems:
+        if self.operatingSystems != None and crashInfo.configuration.os not in self.operatingSystems:
             return False
 
-        if self.products != None and not crashInfo.configuration.product in self.products:
+        if self.products != None and crashInfo.configuration.product not in self.products:
             return False
 
         deferredSymptoms = []
@@ -160,13 +160,13 @@ class CrashSignature():
                 if not symptom.matches(crashInfo):
                     distance += 1
 
-        if self.platforms != None and not crashInfo.configuration.platform in self.platforms:
+        if self.platforms != None and crashInfo.configuration.platform not in self.platforms:
             distance += 1
 
-        if self.operatingSystems != None and not crashInfo.configuration.os in self.operatingSystems:
+        if self.operatingSystems != None and crashInfo.configuration.os not in self.operatingSystems:
             distance += 1
 
-        if self.products != None and not crashInfo.configuration.product in self.products:
+        if self.products != None and crashInfo.configuration.product not in self.products:
             distance += 1
 
         return distance

--- a/FTB/Signatures/CrashSignature.py
+++ b/FTB/Signatures/CrashSignature.py
@@ -79,13 +79,13 @@ class CrashSignature():
         @rtype: bool
         @return: True if the signature matches, False otherwise
         '''
-        if self.platforms != None and crashInfo.configuration.platform not in self.platforms:
+        if self.platforms is not None and crashInfo.configuration.platform not in self.platforms:
             return False
 
-        if self.operatingSystems != None and crashInfo.configuration.os not in self.operatingSystems:
+        if self.operatingSystems is not None and crashInfo.configuration.os not in self.operatingSystems:
             return False
 
-        if self.products != None and crashInfo.configuration.product not in self.products:
+        if self.products is not None and crashInfo.configuration.product not in self.products:
             return False
 
         deferredSymptoms = []
@@ -151,7 +151,7 @@ class CrashSignature():
         for symptom in self.symptoms:
             if isinstance(symptom, StackFramesSymptom):
                 symptomDistance = symptom.diff(crashInfo)[0]
-                if symptomDistance != None:
+                if symptomDistance is not None:
                     distance += symptomDistance
                 else:
                     # If we can't find the distance, assume worst-case
@@ -160,13 +160,13 @@ class CrashSignature():
                 if not symptom.matches(crashInfo):
                     distance += 1
 
-        if self.platforms != None and crashInfo.configuration.platform not in self.platforms:
+        if self.platforms is not None and crashInfo.configuration.platform not in self.platforms:
             distance += 1
 
-        if self.operatingSystems != None and crashInfo.configuration.os not in self.operatingSystems:
+        if self.operatingSystems is not None and crashInfo.configuration.os not in self.operatingSystems:
             distance += 1
 
-        if self.products != None and crashInfo.configuration.product not in self.products:
+        if self.products is not None and crashInfo.configuration.product not in self.products:
             distance += 1
 
         return distance

--- a/FTB/Signatures/JSONHelper.py
+++ b/FTB/Signatures/JSONHelper.py
@@ -120,7 +120,7 @@ def getNumberOrStringChecked(obj, key, mandatory=False):
 
 
 def __getTypeChecked(obj, key, valTypes, mandatory=False):
-    if not key in obj:
+    if key not in obj:
         if mandatory:
             raise RuntimeError('Expected key "%s" in object' % key)
         return None

--- a/FTB/Signatures/Symptom.py
+++ b/FTB/Signatures/Symptom.py
@@ -49,7 +49,7 @@ class Symptom():
         @rtype: Symptom
         @return: Symptom subclass instance matching the given object
         '''
-        if not "type" in obj:
+        if "type" not in obj:
             raise RuntimeError("Missing symptom type in object")
 
         stype = obj["type"]
@@ -238,7 +238,7 @@ class InstructionSymptom(Symptom):
 
         if self.registerNames != None:
             for register in self.registerNames:
-                if not register in crashInfo.crashInstruction:
+                if register not in crashInfo.crashInstruction:
                     return False
 
         if self.instructionName != None:

--- a/FTB/Signatures/Symptom.py
+++ b/FTB/Signatures/Symptom.py
@@ -94,7 +94,7 @@ class OutputSymptom(Symptom):
         self.output = StringMatch(JSONHelper.getObjectOrStringChecked(obj, "value", True))
         self.src = JSONHelper.getStringChecked(obj, "src")
 
-        if self.src != None:
+        if self.src is not None:
             self.src = self.src.lower()
             if self.src != "stderr" and self.src != "stdout" and self.src != "crashdata":
                 raise RuntimeError("Invalid source specified: %s" % self.src)
@@ -111,7 +111,7 @@ class OutputSymptom(Symptom):
         '''
         checkedOutput = []
 
-        if self.src == None:
+        if self.src is None:
             checkedOutput.extend(crashInfo.rawStdout)
             checkedOutput.extend(crashInfo.rawStderr)
             checkedOutput.extend(crashInfo.rawCrashData)
@@ -138,7 +138,7 @@ class StackFrameSymptom(Symptom):
         self.functionName = StringMatch(JSONHelper.getNumberOrStringChecked(obj, "functionName", True))
         self.frameNumber = JSONHelper.getNumberOrStringChecked(obj, "frameNumber")
 
-        if self.frameNumber != None:
+        if self.frameNumber is not None:
             self.frameNumber = NumberMatch(self.frameNumber)
         else:
             # Default to 0
@@ -217,9 +217,9 @@ class InstructionSymptom(Symptom):
         self.registerNames = JSONHelper.getArrayChecked(obj, "registerNames")
         self.instructionName = JSONHelper.getObjectOrStringChecked(obj, "instructionName")
 
-        if self.instructionName != None:
+        if self.instructionName is not None:
             self.instructionName = StringMatch(self.instructionName)
-        elif self.registerNames == None or len(self.registerNames) == 0:
+        elif self.registerNames is None or len(self.registerNames) == 0:
             raise RuntimeError("Must provide at least instruction name or register names")
 
     def matches(self, crashInfo):
@@ -232,16 +232,16 @@ class InstructionSymptom(Symptom):
         @rtype: bool
         @return: True if the symptom matches, False otherwise
         '''
-        if crashInfo.crashInstruction == None:
+        if crashInfo.crashInstruction is None:
             # No crash instruction available, do not match
             return False
 
-        if self.registerNames != None:
+        if self.registerNames is not None:
             for register in self.registerNames:
                 if register not in crashInfo.crashInstruction:
                     return False
 
-        if self.instructionName != None:
+        if self.instructionName is not None:
             if not self.instructionName.matches(crashInfo.crashInstruction):
                 return False
 
@@ -268,7 +268,7 @@ class TestcaseSymptom(Symptom):
         '''
 
         # No testcase means to fail matching
-        if crashInfo.testcase == None:
+        if crashInfo.testcase is None:
             return False
 
         testLines = crashInfo.testcase.splitlines()
@@ -312,7 +312,7 @@ class StackFramesSymptom(Symptom):
 
         for depth in range(1, 4):
             (bestDepth, bestGuess) = StackFramesSymptom._diff(crashInfo.backtrace, self.functionNames, 0, 1, depth)
-            if bestDepth != None:
+            if bestDepth is not None:
                 guessedFunctionNames = [repr(x) for x in bestGuess]
 
                 # Remove trailing wildcards as they are of no use
@@ -352,7 +352,7 @@ class StackFramesSymptom(Symptom):
                 (newBestDepth, newBestGuess) = StackFramesSymptom._diff(stack, newSignatureGuess, idx,
                                                                         depth + 1, maxDepth)
 
-                if newBestDepth != None and (bestDepth == None or newBestDepth < bestDepth):
+                if newBestDepth is not None and (bestDepth is None or newBestDepth < bestDepth):
                     bestDepth = newBestDepth
                     bestGuess = newBestGuess
 
@@ -395,7 +395,7 @@ class StackFramesSymptom(Symptom):
                 (newBestDepth, newBestGuess) = StackFramesSymptom._diff(stack, newSignatureGuess, idx,
                                                                         depth + 1, maxDepth)
 
-                if newBestDepth != None and (bestDepth == None or newBestDepth < bestDepth):
+                if newBestDepth is not None and (bestDepth is None or newBestDepth < bestDepth):
                     bestDepth = newBestDepth
                     bestGuess = newBestGuess
 

--- a/FTB/Signatures/test_CrashInfo.py
+++ b/FTB/Signatures/test_CrashInfo.py
@@ -191,7 +191,7 @@ Crash Annotation GraphicsCriticalError: |[C0][GFX1-]: Receive IPC close with rea
 asanTruncatedTrace = """
 ==8986==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7fcfcfaadeda bp 0x7fcfcb405340 sp 0x7fcfcb405320 T2)
 ==8986==The signal is caused by a WRITE memory access.
-"""
+"""  # noqa
 
 gdbCrashAddress1 = """
 (gdb) bt 16

--- a/FTB/Signatures/test_CrashInfo.py
+++ b/FTB/Signatures/test_CrashInfo.py
@@ -811,7 +811,7 @@ class ASanParserTestMultiTrace(unittest.TestCase):
         self.assertEqual(crashInfo.backtrace[3], "CreateThread")
         self.assertEqual("[@ mozilla::ipc::Shmem::OpenExisting]", crashInfo.createShortSignature())
 
-        
+
 class ASanParserTestTruncatedTrace(unittest.TestCase):
     def runTest(self):
         config = ProgramConfiguration("test", "x86-64", "linux")
@@ -827,7 +827,7 @@ class ASanParserTestTruncatedTrace(unittest.TestCase):
         self.assertEqual(crashSig, None)
         self.assertTrue("Insufficient data" in crashInfo.failureReason)
 
-        
+
 class GDBParserTestCrash(unittest.TestCase):
     def runTest(self):
         config = ProgramConfiguration("test", "x86", "linux")

--- a/FTB/Signatures/test_CrashSignature.py
+++ b/FTB/Signatures/test_CrashSignature.py
@@ -7,7 +7,7 @@ import json
 import unittest
 
 from FTB.ProgramConfiguration import ProgramConfiguration
-from FTB.Signatures.CrashInfo import CrashInfo, NoCrashInfo
+from FTB.Signatures.CrashInfo import CrashInfo
 from FTB.Signatures.CrashSignature import CrashSignature
 from FTB.Signatures.Matchers import StringMatch
 from FTB.Signatures.Symptom import StackFramesSymptom

--- a/FTB/test_AssertionHelper.py
+++ b/FTB/test_AssertionHelper.py
@@ -163,13 +163,13 @@ class AssertionHelperTestChakraAssert(unittest.TestCase):
 class AssertionHelperTestWindowsPathSanitizing(unittest.TestCase):
     def runTest(self):
         err1 = windowsPathAssertFwdSlashes.splitlines()
-        err2 = windowsPathAssertBwSlashes.splitlines()
+        # err2 = windowsPathAssertBwSlashes.splitlines()
 
         assertionMsg1 = AssertionHelper.getAssertion(err1)
-        assertionMsg2 = AssertionHelper.getAssertion(err2)
+        # assertionMsg2 = AssertionHelper.getAssertion(err2)
 
         sanitizedMsg1 = AssertionHelper.getSanitizedAssertionPattern(assertionMsg1)
-        sanitizedMsg2 = AssertionHelper.getSanitizedAssertionPattern(assertionMsg2)
+        # sanitizedMsg2 = AssertionHelper.getSanitizedAssertionPattern(assertionMsg2)
 
         expectedMsg = ("Assertion failure: block\\->graph\\(\\)\\.osrBlock\\(\\), at "
                        "([a-zA-Z]:)?/.+/Lowering\\.cpp(:[0-9]+)+")

--- a/Reporter/Reporter.py
+++ b/Reporter/Reporter.py
@@ -27,7 +27,7 @@ BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 FTB_PATH = os.path.abspath(os.path.join(BASE_DIR, ".."))
 sys.path += [FTB_PATH]
 
-from FTB.ConfigurationFiles import ConfigurationFiles
+from FTB.ConfigurationFiles import ConfigurationFiles  # noqa
 
 
 def remote_checks(f):

--- a/misc/ec2prices/simulations/best_every_n_hours.py
+++ b/misc/ec2prices/simulations/best_every_n_hours.py
@@ -27,7 +27,7 @@ def run(data, sim_config, main_config):
     zone = data[region].keys()[0]
     instance_type = data[region][zone].keys()[0]
 
-    if not "n" in sim_config:
+    if "n" not in sim_config:
         print("Error: Must specify parameter 'n' for best_every_n_hours handler.")
         return None
 

--- a/misc/ec2prices/simulator.py
+++ b/misc/ec2prices/simulator.py
@@ -65,7 +65,7 @@ def get_spot_price_per_region(region_name, start_time, end_time, aws_key_id, aws
                                               product_description="Linux/UNIX"
                                               )  # TODO: Make configurable
             break
-        except:
+        except Exception:
             print("Caught exception, retrying")
             pass
 

--- a/misc/ec2prices/simulator.py
+++ b/misc/ec2prices/simulator.py
@@ -22,7 +22,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Ensure print() compatibility with Python 3
 from __future__ import print_function
 
-import argparse
 import boto.ec2
 from collections import OrderedDict
 import datetime

--- a/misc/ec2prices/simulator.py
+++ b/misc/ec2prices/simulator.py
@@ -92,15 +92,15 @@ def get_spot_prices(regions, start_time, end_time, aws_key_id, aws_secret_key, i
         if use_multiprocess:
             result = result.get()
         for entry in result:
-            if not entry.region.name in prices:
+            if entry.region.name not in prices:
                 prices[entry.region.name] = {}
 
             zone = entry.availability_zone
 
-            if not zone in prices[entry.region.name]:
+            if zone not in prices[entry.region.name]:
                 prices[entry.region.name][zone] = {}
 
-            if not entry.instance_type in prices[entry.region.name][zone]:
+            if entry.instance_type not in prices[entry.region.name][zone]:
                 prices[entry.region.name][zone][entry.instance_type] = OrderedDict()
 
             if not start_time.isoformat() in prices[entry.region.name][zone][entry.instance_type]:
@@ -136,13 +136,13 @@ class ConfigurationFile():
                                        "cache_file"]
 
                     for mandatoryField in mandatoryFields:
-                        if not mandatoryField in sectionMap:
+                        if mandatoryField not in sectionMap:
                             print("Error: Main configuration is missing mandatory field '%s'." % mandatoryField)
                             return
 
                     self.main = sectionMap
                 else:
-                    if not "handler" in sectionMap:
+                    if "handler" not in sectionMap:
                         print("Warning: Simulation '%s' has no handler set, ignoring..." % section)
                         continue
 

--- a/misc/libfuzzer/libfuzzer.py
+++ b/misc/libfuzzer/libfuzzer.py
@@ -30,9 +30,9 @@ BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 FTB_PATH = os.path.abspath(os.path.join(BASE_DIR, "..", ".."))
 sys.path += [FTB_PATH]
 
-from Collector.Collector import Collector
-from FTB.ProgramConfiguration import ProgramConfiguration
-from FTB.Signatures.CrashInfo import CrashInfo
+from Collector.Collector import Collector  # noqa
+from FTB.ProgramConfiguration import ProgramConfiguration  # noqa
+from FTB.Signatures.CrashInfo import CrashInfo  # noqa
 
 
 class LibFuzzerMonitor(threading.Thread):

--- a/misc/libfuzzer/libfuzzer.py
+++ b/misc/libfuzzer/libfuzzer.py
@@ -183,7 +183,7 @@ def main(argv=None):
         configuration.addMetadata(metadata)
 
     # Set LD_LIBRARY_PATH for convenience
-    if not 'LD_LIBRARY_PATH' in env:
+    if 'LD_LIBRARY_PATH' not in env:
         env['LD_LIBRARY_PATH'] = os.path.dirname(binary)
 
     serverauthtoken = None

--- a/misc/libfuzzer/libfuzzer.py
+++ b/misc/libfuzzer/libfuzzer.py
@@ -148,11 +148,11 @@ def main(argv=None):
         return 2
 
     configuration = ProgramConfiguration.fromBinary(binary)
-    if configuration == None:
+    if configuration is None:
         print("Error: Failed to load program configuration based on binary", file=sys.stderr)
         return 2
 
-        if opts.platform == None or opts.product == None or opts.os == None:
+        if opts.platform is None or opts.product is None or opts.os is None:
             print(("Error: Must use binary configuration file or specify/configure at least "
                    "--platform, --product and --os"), file=sys.stderr)
             return 2
@@ -219,7 +219,7 @@ def main(argv=None):
 
         (sigfile, metadata) = collector.search(crashInfo)
 
-        if sigfile != None:
+        if sigfile is not None:
             if last_signature == sigfile:
                 signature_repeat_count += 1
             else:

--- a/server/common/views.py
+++ b/server/common/views.py
@@ -3,7 +3,6 @@ from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.db.models import Q
 from django.shortcuts import render
 import json
-import operator
 from rest_framework import filters
 
 from ..crashmanager.serializers import InvalidArgumentException

--- a/server/common/views.py
+++ b/server/common/views.py
@@ -1,8 +1,12 @@
+from collections import OrderedDict
 from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.db.models import Q
+from django.shortcuts import render
 import json
 import operator
 from rest_framework import filters
+
+from ..crashmanager.serializers import InvalidArgumentException
 
 
 def renderError(request, err):

--- a/server/common/views.py
+++ b/server/common/views.py
@@ -82,7 +82,7 @@ def json_to_query(json_str):
 
         qobj = Q()
 
-        if not "op" in obj:
+        if "op" not in obj:
                 raise RuntimeError("No operator specified in query object")
 
         op = obj["op"]

--- a/server/common/views.py
+++ b/server/common/views.py
@@ -37,7 +37,7 @@ def paginate_requested_list(request, entries):
     # We need to preserve the query parameters when adding the page to the
     # query URL, so we store the sanitized copy inside our entries object.
     paginator_query = request.GET.copy()
-    if paginator_query.has_key('page'):
+    if 'page' in paginator_query:
         del paginator_query['page']
 
     page_entries.paginator_query = paginator_query

--- a/server/common/views.py
+++ b/server/common/views.py
@@ -1,15 +1,11 @@
-from collections import OrderedDict
 from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.db.models import Q
-from django.shortcuts import render
 import json
 from rest_framework import filters
 
-from ..crashmanager.serializers import InvalidArgumentException
-
 
 def renderError(request, err):
-    return render(request, 'error.html', {'error_message': err})
+    return render(request, 'error.html', {'error_message': err})  # noqa
 
 
 def paginate_requested_list(request, entries):
@@ -70,7 +66,7 @@ def json_to_query(json_str):
     then the operator has no effect.
     """
     try:
-        obj = json.loads(json_str, object_pairs_hook=OrderedDict)
+        obj = json.loads(json_str, object_pairs_hook=OrderedDict)  # noqa
     except ValueError as e:
         raise RuntimeError("Invalid JSON: %s" % e)
 
@@ -124,7 +120,7 @@ class JsonQueryFilterBackend(filters.BaseFilterBackend):
             try:
                 _, queryobj = json_to_query(querystr)
             except RuntimeError as e:
-                raise InvalidArgumentException("error in query: %s" % e)
+                raise InvalidArgumentException("error in query: %s" % e)  # noqa
             queryset = queryset.filter(queryobj)
         return queryset
 

--- a/server/covmanager/SourceCodeProvider/test_sourcecodeprovider.py
+++ b/server/covmanager/SourceCodeProvider/test_sourcecodeprovider.py
@@ -12,7 +12,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 @contact:    choller@mozilla.com
 '''
 
-import json
 import os
 import unittest
 

--- a/server/covmanager/models.py
+++ b/server/covmanager/models.py
@@ -6,7 +6,6 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch.dispatcher import receiver
 from django.utils import timezone
 import json
-import re
 
 from crashmanager.models import Client, Tool
 

--- a/server/covmanager/models.py
+++ b/server/covmanager/models.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.contrib.auth.models import User as DjangoUser
+from django.contrib.auth.models import User as DjangoUser  # noqa
 from django.core.files.storage import FileSystemStorage
 from django.db import models
 from django.db.models.signals import post_delete, post_save

--- a/server/covmanager/serializers.py
+++ b/server/covmanager/serializers.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import MultipleObjectsReturned
+from django.core.exceptions import MultipleObjectsReturned  # noqa
 from django.core.files.base import ContentFile
 import hashlib
 from rest_framework import serializers

--- a/server/covmanager/tasks.py
+++ b/server/covmanager/tasks.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from django.conf import settings
 import os
 import sys

--- a/server/covmanager/tasks.py
+++ b/server/covmanager/tasks.py
@@ -7,7 +7,7 @@ import sys
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path += [os.path.abspath(os.path.join(BASE_DIR, ".."))]
 
-from celeryconf import app
+from celeryconf import app  # noqa
 
 
 @app.task

--- a/server/covmanager/tasks.py
+++ b/server/covmanager/tasks.py
@@ -1,4 +1,4 @@
-from django.conf import settings
+from django.conf import settings  # noqa
 import os
 import sys
 

--- a/server/covmanager/tasks.py
+++ b/server/covmanager/tasks.py
@@ -12,7 +12,7 @@ from celeryconf import app  # noqa
 
 @app.task
 def check_revision_update(pk):
-    from covmanager.models import Collection, Repository
+    from covmanager.models import Collection, Repository  # noqa
     collection = Collection.objects.get(pk=pk)
 
     # Get the SourceCodeProvider associated with this collection

--- a/server/covmanager/tests/test_collections_rest.py
+++ b/server/covmanager/tests/test_collections_rest.py
@@ -14,7 +14,7 @@ import json
 import logging
 
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse  # noqa
 from django.utils import dateparse, timezone
 from rest_framework.test import APITestCase  # APIRequestFactory
 import requests

--- a/server/covmanager/tests/test_mgmt_setup_repository.py
+++ b/server/covmanager/tests/test_mgmt_setup_repository.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 import pytest
 from django.core.management import call_command, CommandError

--- a/server/covmanager/tests/test_repositories_rest.py
+++ b/server/covmanager/tests/test_repositories_rest.py
@@ -13,7 +13,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import json
 import logging
 
-import pytest
 import requests
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse

--- a/server/covmanager/tests/test_repositories_rest.py
+++ b/server/covmanager/tests/test_repositories_rest.py
@@ -15,7 +15,7 @@ import logging
 
 import requests
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse  # noqa
 from rest_framework.test import APITestCase
 
 from . import TestCase

--- a/server/covmanager/views.py
+++ b/server/covmanager/views.py
@@ -8,7 +8,7 @@ from rest_framework import mixins, viewsets, filters
 from rest_framework.authentication import TokenAuthentication, \
     SessionAuthentication
 
-from common.views import JsonQueryFilterBackend, SimpleQueryFilterBackend, paginate_requested_list, renderError
+from common.views import JsonQueryFilterBackend, SimpleQueryFilterBackend
 
 from .models import Collection, Repository
 from .serializers import CollectionSerializer, RepositorySerializer

--- a/server/covmanager/views.py
+++ b/server/covmanager/views.py
@@ -146,7 +146,7 @@ def collections_diff_api(request, path):
     for child in start_coverage["children"]:
         add = {}
 
-        if not child in end_coverage["children"]:
+        if child not in end_coverage["children"]:
             continue
 
         for k in start_coverage["children"][child]:

--- a/server/crashmanager/Bugtracker/BugzillaProvider.py
+++ b/server/crashmanager/Bugtracker/BugzillaProvider.py
@@ -302,7 +302,7 @@ class BugzillaProvider(Provider):
 
         # If we have a binary testcase or the testcase is too large,
         # attach it here in a second step
-        if crashEntry.testcase != None:
+        if crashEntry.testcase is not None:
             crashEntry.testcase.test.open(mode='rb')
             data = crashEntry.testcase.test.read()
             crashEntry.testcase.test.close()
@@ -363,7 +363,7 @@ class BugzillaProvider(Provider):
 
         # If we have a binary testcase or the testcase is too large,
         # attach it here in a second step
-        if crashEntry.testcase != None:
+        if crashEntry.testcase is not None:
             crashEntry.testcase.test.open(mode='rb')
             data = crashEntry.testcase.test.read()
             crashEntry.testcase.test.close()

--- a/server/crashmanager/Bugtracker/BugzillaProvider.py
+++ b/server/crashmanager/Bugtracker/BugzillaProvider.py
@@ -177,7 +177,7 @@ class BugzillaProvider(Provider):
             # Find all metadata variables requested for subtitution
             metadataVars = re.findall("%metadata\.([a-zA-Z0-9_\-]+)%", source)
             for mVar in metadataVars:
-                if not mVar in metadata:
+                if mVar not in metadata:
                     metadata[mVar] = "(%s not available)" % mVar
 
                 source = source.replace('%metadata.' + mVar + '%', metadata[mVar])
@@ -263,7 +263,7 @@ class BugzillaProvider(Provider):
 
         # Remove any other variables that we don't want to pass on
         for key in request.POST:
-            if not key in self.templateFields:
+            if key not in self.templateFields:
                 del(args[key])
 
         # Convert the attrs field to a dict
@@ -291,7 +291,7 @@ class BugzillaProvider(Provider):
         # Create the bug
         bz = BugzillaREST(self.hostname, username, password, api_key)
         ret = bz.createBug(**args)
-        if not "id" in ret:
+        if "id" not in ret:
             raise RuntimeError("Failed to create bug: %s", ret)
 
         # If we were told to attach the crash data, do so now
@@ -352,7 +352,7 @@ class BugzillaProvider(Provider):
         bz = BugzillaREST(self.hostname, username, password, api_key)
 
         ret = bz.createComment(**args)
-        if not "id" in ret:
+        if "id" not in ret:
             raise RuntimeError("Failed to create comment: %s", ret)
 
         # If we were told to attach the crash data, do so now

--- a/server/crashmanager/Bugtracker/BugzillaREST.py
+++ b/server/crashmanager/Bugtracker/BugzillaREST.py
@@ -57,7 +57,7 @@ class BugzillaREST():
         response = requests.get(loginUrl)
         json = response.json()
 
-        if not 'token' in json:
+        if 'token' not in json:
             raise RuntimeError('Login failed: %s', response.text)
 
         self.authToken = json["token"]
@@ -94,7 +94,7 @@ class BugzillaREST():
         response = requests.get(bugUrl + "".join(extraParams))
         json = response.json()
 
-        if not "bugs" in json:
+        if "bugs" not in json:
             return None
 
         ret = {}
@@ -142,7 +142,7 @@ class BugzillaREST():
         createUrl = "%s/bug/%s/comment?%s=%s" % (self.baseUrl, id, self.authField, self.authToken)
         response = requests.post(createUrl, cobj).json()
 
-        if not "id" in response:
+        if "id" not in response:
             return response
 
         commentId = str(response["id"])
@@ -150,10 +150,10 @@ class BugzillaREST():
         commentUrl = "%s/bug/comment/%s?%s=%s" % (self.baseUrl, commentId, self.authField, self.authToken)
         response = requests.get(commentUrl).json()
 
-        if not "comments" in response:
+        if "comments" not in response:
             return response
 
-        if not commentId in response["comments"]:
+        if commentId not in response["comments"]:
             return response
 
         return response["comments"][commentId]

--- a/server/crashmanager/Bugtracker/BugzillaREST.py
+++ b/server/crashmanager/Bugtracker/BugzillaREST.py
@@ -32,11 +32,11 @@ class BugzillaREST():
         # method we use (username/password means we need to use token, with
         # API key we can use the api_key field directly).
         self.authField = 'token'
-        if self.api_key != None:
+        if self.api_key is not None:
             self.authField = 'api_key'
 
     def login(self, forceLogin=False):
-        if (self.username == None or self.password == None) and self.api_key == None:
+        if (self.username is None or self.password is None) and self.api_key is None:
             if forceLogin:
                 raise RuntimeError("Need username/password or API key to login.")
             else:
@@ -45,12 +45,12 @@ class BugzillaREST():
         if forceLogin:
             self.authToken = None
 
-        if self.api_key != None:
+        if self.api_key is not None:
             self.authToken = self.api_key
 
         # We either use an API key which doesn't require any prior login
         # or we still have a valid authentication token that we can use.
-        if self.authToken != None:
+        if self.authToken is not None:
             return True
 
         loginUrl = "%s/login?login=%s&password=%s" % (self.baseUrl, self.username, self.password)
@@ -114,10 +114,10 @@ class BugzillaREST():
         loc = locals()
         bug = {}
         for k in loc:
-            if k == "attrs" and loc[k] != None:
+            if k == "attrs" and loc[k] is not None:
                 for ak in loc[k]:
                     bug[ak] = loc[k][ak]
-            elif loc[k] != None and loc[k] != '' and k != "self":
+            elif loc[k] is not None and loc[k] != '' and k != "self":
                 bug[k] = loc[k]
 
         # Ensure we're logged in
@@ -164,7 +164,7 @@ class BugzillaREST():
         loc = locals()
         attachment = {}
         for k in loc:
-            if loc[k] != None and loc[k] != '' and k != "self" and k != "is_binary":
+            if loc[k] is not None and loc[k] != '' and k != "self" and k != "is_binary":
                 attachment[k] = loc[k]
 
         # Set proper content-type

--- a/server/crashmanager/__init__.py
+++ b/server/crashmanager/__init__.py
@@ -1,1 +1,1 @@
-from . import tasks
+from . import tasks  # noqa

--- a/server/crashmanager/management/commands/bug_update_status.py
+++ b/server/crashmanager/management/commands/bug_update_status.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
                 # with the same external bug id. Make sure we consider all of them.
                 bugs = providerBugs.filter(externalId=bugId)
                 for bug in bugs:
-                    if bugStatus[bugId] == None and bug.closed != None:
+                    if bugStatus[bugId] is None and bug.closed is not None:
                         bug.closed = None
                         bug.save()
                     elif isinstance(bugStatus[bugId], str):
@@ -55,6 +55,6 @@ class Command(BaseCommand):
                         bug.externalId = bugStatus[bugId]
                         bug.closed = None
                         bug.save()
-                    elif bug.closed == None:
+                    elif bug.closed is None:
                         bug.closed = bugStatus[bugId]
                         bug.save()

--- a/server/crashmanager/management/commands/cleanup_old_crashes.py
+++ b/server/crashmanager/management/commands/cleanup_old_crashes.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from django.conf import settings
-from django.core.management import BaseCommand, CommandError
+from django.core.management import BaseCommand, CommandError  # noqa
 from django.db.models.aggregates import Count
 from django.utils import timezone
 

--- a/server/crashmanager/management/commands/export_signatures.py
+++ b/server/crashmanager/management/commands/export_signatures.py
@@ -1,6 +1,4 @@
 import json
-import os
-import shutil
 from zipfile import ZipFile
 
 from django.core.management.base import BaseCommand

--- a/server/crashmanager/management/commands/triage_new_crashes.py
+++ b/server/crashmanager/management/commands/triage_new_crashes.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
             crashInfo = entry.getCrashInfo(attachTestcase=True)
 
             for bucket in buckets:
-                if not bucket.pk in signatureCache:
+                if bucket.pk not in signatureCache:
                     signatureCache[bucket.pk] = bucket.getSignature()
 
                 signature = signatureCache[bucket.pk]

--- a/server/crashmanager/management/commands/triage_new_crashes.py
+++ b/server/crashmanager/management/commands/triage_new_crashes.py
@@ -1,4 +1,4 @@
-from django.core.management import BaseCommand, CommandError
+from django.core.management import BaseCommand, CommandError  # noqa
 
 from crashmanager.management.common import mgmt_lock_required
 from crashmanager.models import CrashEntry, Bucket

--- a/server/crashmanager/migrations/0005_add_user.py
+++ b/server/crashmanager/migrations/0005_add_user.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 from django.conf import settings
-from crashmanager.models import Tool
+from crashmanager.models import Tool  # noqa
 
 
 class Migration(migrations.Migration):

--- a/server/crashmanager/migrations/0009_copy_crashaddress.py
+++ b/server/crashmanager/migrations/0009_copy_crashaddress.py
@@ -13,7 +13,7 @@ def create_migration_tool(apps, schema_editor):
     for entry in CrashEntry.objects.filter(crashAddressNumeric=None):
         try:
             entry.save()
-        except ValueError as e:
+        except ValueError:
             print("Failed to convert crash address value: %s" % entry.crashAddress, file=sys.stderr)
 
 

--- a/server/crashmanager/migrations/0009_copy_crashaddress.py
+++ b/server/crashmanager/migrations/0009_copy_crashaddress.py
@@ -3,8 +3,8 @@ from __future__ import unicode_literals, print_function
 
 import sys
 
-from django.db import models, migrations
-from django.conf import settings
+from django.db import models, migrations  # noqa
+from django.conf import settings  # noqa
 
 
 def create_migration_tool(apps, schema_editor):

--- a/server/crashmanager/migrations/0018_auto_20170620_1503.py
+++ b/server/crashmanager/migrations/0018_auto_20170620_1503.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import django.core.files.storage
+import django.core.files.storage  # noqa
 
 
 class Migration(migrations.Migration):

--- a/server/crashmanager/models.py
+++ b/server/crashmanager/models.py
@@ -259,11 +259,11 @@ class CrashEntry(models.Model):
     def deferRawFields(queryset, requiredOutputSources=()):
         # This method calls defer() on the given query set for every raw field
         # that is not required as specified in requiredOutputSources.
-        if not "stdout" in requiredOutputSources:
+        if "stdout" not in requiredOutputSources:
             queryset = queryset.defer('rawStdout')
-        if not "stderr" in requiredOutputSources:
+        if "stderr" not in requiredOutputSources:
             queryset = queryset.defer('rawStderr')
-        if not "crashdata" in requiredOutputSources:
+        if "crashdata" not in requiredOutputSources:
             queryset = queryset.defer('rawCrashData')
         return queryset
 

--- a/server/crashmanager/models.py
+++ b/server/crashmanager/models.py
@@ -221,7 +221,7 @@ class CrashEntry(models.Model):
         crashInfo = CrashInfo.fromRawCrashData(rawStdout, rawStderr, configuration, rawCrashData,
                                                cacheObject=cachedCrashInfo)
 
-        if attachTestcase and self.testcase != None and not self.testcase.isBinary:
+        if attachTestcase and self.testcase is not None and not self.testcase.isBinary:
             self.testcase.loadTest()
             crashInfo.testcase = self.testcase.content
 
@@ -236,7 +236,7 @@ class CrashEntry(models.Model):
         # has changed or the implementation parsing it was updated.
         self.cachedCrashInfo = None
         crashInfo = self.getCrashInfo()
-        if crashInfo.crashAddress != None:
+        if crashInfo.crashAddress is not None:
             self.crashAddress = hex(crashInfo.crashAddress)
         self.shortSignature = crashInfo.createShortSignature()
 

--- a/server/crashmanager/serializers.py
+++ b/server/crashmanager/serializers.py
@@ -1,7 +1,7 @@
 import base64
-from django.core.exceptions import MultipleObjectsReturned
+from django.core.exceptions import MultipleObjectsReturned  # noqa
 from django.core.files.base import ContentFile
-from django.forms import widgets
+from django.forms import widgets  # noqa
 import hashlib
 from rest_framework import serializers
 from rest_framework.exceptions import APIException

--- a/server/crashmanager/tasks.py
+++ b/server/crashmanager/tasks.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from django.conf import settings
 
 from celeryconf import app
-from . import cron  # ensure cron tasks get registered
+from . import cron  # noqa ensure cron tasks get registered
 
 # This is a per-worker global cache mapping short descriptions of
 # crashes to a list of bucket candidates to try first.

--- a/server/crashmanager/tasks.py
+++ b/server/crashmanager/tasks.py
@@ -1,6 +1,4 @@
 from collections import OrderedDict
-import os
-import sys
 
 from django.conf import settings
 

--- a/server/crashmanager/tests/test_bugs.py
+++ b/server/crashmanager/tests/test_bugs.py
@@ -10,10 +10,8 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 '''
 
-import json
 import logging
 
-import pytest
 import requests
 from django.core.urlresolvers import reverse
 

--- a/server/crashmanager/tests/test_signatures.py
+++ b/server/crashmanager/tests/test_signatures.py
@@ -189,7 +189,7 @@ class FindSignatureTests(TestCase):
         """No errors are thrown in template"""
         self.client.login(username='test', password='test')
         crash = self.create_crash()
-        bucket = self.create_bucket(signature=json.dumps({"symptoms": [
+        self.create_bucket(signature=json.dumps({"symptoms": [
             {'src': 'stderr',
              'type': 'output',
              'value': '//'}]}))
@@ -630,7 +630,7 @@ class DelSignatureTests(TestCase):
         self.assertEqual(response.status_code, requests.codes['ok'])
         self.assertContains(response, "Are you sure that you want to delete this signature?")
         self.assertContains(response, self.entries_fmt % 0)
-        crash = self.create_crash(shortSignature='crash #1', bucket=bucket)
+        self.create_crash(shortSignature='crash #1', bucket=bucket)
         response = self.client.get(reverse(self.name, kwargs={"sigid": bucket.pk}))
         log.debug(response)
         self.assertEqual(response.status_code, requests.codes['ok'])
@@ -662,7 +662,7 @@ class DelSignatureTests(TestCase):
         """Test deleting a signature with crashes and removing entries"""
         self.client.login(username='test', password='test')
         bucket = self.create_bucket(shortDescription='bucket #1')
-        crash = self.create_crash(shortSignature='crash #1', bucket=bucket)
+        self.create_crash(shortSignature='crash #1', bucket=bucket)
         response = self.client.post(reverse(self.name, kwargs={"sigid": bucket.pk}), {'delentries': '1'})
         log.debug(response)
         self.assertRedirects(response, reverse('crashmanager:signatures'))

--- a/server/crashmanager/tests/test_signatures_rest.py
+++ b/server/crashmanager/tests/test_signatures_rest.py
@@ -12,7 +12,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
 import logging
-import os.path
 
 import requests
 from django.contrib.auth.models import User

--- a/server/crashmanager/tests/test_signatures_rest.py
+++ b/server/crashmanager/tests/test_signatures_rest.py
@@ -18,7 +18,6 @@ from django.contrib.auth.models import User
 from rest_framework.test import APITestCase  # APIRequestFactory
 
 from . import TestCase
-from ..models import CrashEntry, TestCase as cmTestCase
 
 
 log = logging.getLogger("fm.crashmanager.tests.signatures.rest")  # pylint: disable=invalid-name

--- a/server/crashmanager/tests/test_stats.py
+++ b/server/crashmanager/tests/test_stats.py
@@ -54,10 +54,10 @@ class StatsViewTests(TestCase):
         """Insert crashes and check that they are shown ok."""
         self.client.login(username='test', password='test')
         bucket = self.create_bucket(shortDescription="bucket #1")
-        (self.create_crash(shortSignature="crash #1", tool="tool #1"),
-         self.create_crash(shortSignature="crash #2", tool="tool #1", bucket=bucket),
-         self.create_crash(shortSignature="crash #3", tool="tool #1", bucket=bucket),
-         self.create_crash(shortSignature="crash #4", tool="tool #2"))
+        self.create_crash(shortSignature="crash #1", tool="tool #1")
+        self.create_crash(shortSignature="crash #2", tool="tool #1", bucket=bucket)
+        self.create_crash(shortSignature="crash #3", tool="tool #1", bucket=bucket)
+        self.create_crash(shortSignature="crash #4", tool="tool #2")
         self.create_toolfilter("tool #1")
         response = self.client.get(reverse(self.name))
         self.assertEqual(response.status_code, requests.codes['ok'])

--- a/server/crashmanager/tests/test_stats.py
+++ b/server/crashmanager/tests/test_stats.py
@@ -43,7 +43,7 @@ class StatsViewTests(TestCase):
     def test_with_crash(self):
         """Insert one crash and check that it is shown ok."""
         self.client.login(username='test', password='test')
-        crash = self.create_crash(shortSignature="crash #1")
+        self.create_crash(shortSignature="crash #1")
         response = self.client.get(reverse(self.name))
         self.assertEqual(response.status_code, requests.codes['ok'])
         self.assertEqual(response.context['total_reports_per_hour'], 1)
@@ -54,10 +54,10 @@ class StatsViewTests(TestCase):
         """Insert crashes and check that they are shown ok."""
         self.client.login(username='test', password='test')
         bucket = self.create_bucket(shortDescription="bucket #1")
-        crashes = (self.create_crash(shortSignature="crash #1", tool="tool #1"),
-                   self.create_crash(shortSignature="crash #2", tool="tool #1", bucket=bucket),
-                   self.create_crash(shortSignature="crash #3", tool="tool #1", bucket=bucket),
-                   self.create_crash(shortSignature="crash #4", tool="tool #2"))
+        (self.create_crash(shortSignature="crash #1", tool="tool #1"),
+         self.create_crash(shortSignature="crash #2", tool="tool #1", bucket=bucket),
+         self.create_crash(shortSignature="crash #3", tool="tool #1", bucket=bucket),
+         self.create_crash(shortSignature="crash #4", tool="tool #2"))
         self.create_toolfilter("tool #1")
         response = self.client.get(reverse(self.name))
         self.assertEqual(response.status_code, requests.codes['ok'])

--- a/server/crashmanager/views.py
+++ b/server/crashmanager/views.py
@@ -860,8 +860,8 @@ def optimizeSignature(request, sigid):
             # If the signature matches lots of other buckets as well, it is likely too
             # broad and we should not consider it (or later rate it worse than others).
             matchesInOtherBuckets = False
-            nonMatchesInOtherBuckets = 0
-            otherMatchingBucketIds = []
+            nonMatchesInOtherBuckets = 0  # noqa
+            otherMatchingBucketIds = []  # noqa
             for otherBucket in buckets:
                 if otherBucket.pk == bucket.pk:
                     continue

--- a/server/crashmanager/views.py
+++ b/server/crashmanager/views.py
@@ -115,7 +115,7 @@ def paginate_requested_list(request, entries):
     # We need to preserve the query parameters when adding the page to the
     # query URL, so we store the sanitized copy inside our entries object.
     paginator_query = request.GET.copy()
-    if paginator_query.has_key('page'):
+    if 'page' in paginator_query:
         del paginator_query['page']
 
     page_entries.paginator_query = paginator_query

--- a/server/crashmanager/views.py
+++ b/server/crashmanager/views.py
@@ -25,7 +25,7 @@ def check_authorized_for_crash_entry(request, entry):
     user = User.get_or_create_restricted(request.user)[0]
     if user.restricted:
         defaultToolsFilter = user.defaultToolsFilter.all()
-        if not defaultToolsFilter or not entry.tool in defaultToolsFilter:
+        if not defaultToolsFilter or entry.tool not in defaultToolsFilter:
             raise PermissionDenied({"message": "You don't have permission to access this crash entry."})
 
     return
@@ -292,7 +292,7 @@ def signatures(request):
 
     # Do not display triaged crash entries unless there is an all=1 parameter
     # specified in the search query. Otherwise only show untriaged entries.
-    if (not "all" in request.GET or not request.GET["all"]) and not isSearch:
+    if ("all" not in request.GET or not request.GET["all"]) and not isSearch:
         filters["bug"] = None
 
     entries = entries.filter(**filters)
@@ -358,7 +358,7 @@ def crashes(request, ignore_toolfilter=False):
 
     # Do not display triaged crash entries unless there is an all=1 parameter
     # specified in the search query. Otherwise only show untriaged entries.
-    if not "all" in request.GET or not request.GET["all"]:
+    if "all" not in request.GET or not request.GET["all"]:
         filters["bucket"] = None
 
     entries = entries.filter(**filters)
@@ -673,7 +673,7 @@ def deleteSignature(request, sigid):
     check_authorized_for_signature(request, bucket)
 
     if request.method == 'POST':
-        if not "delentries" in request.POST:
+        if "delentries" not in request.POST:
             # Make sure we remove this bucket from all crash entries referring to it,
             # otherwise these would be deleted as well through cascading.
             CrashEntry.objects.filter(bucket=bucket).update(bucket=None, triagedOnce=False)
@@ -866,7 +866,7 @@ def optimizeSignature(request, sigid):
                 if otherBucket.pk == bucket.pk:
                     continue
 
-                if not otherBucket.pk in firstEntryPerBucketCache:
+                if otherBucket.pk not in firstEntryPerBucketCache:
                     c = CrashEntry.objects.filter(bucket=otherBucket).select_related("product", "platform", "os")
                     c = CrashEntry.deferRawFields(c, requiredOutputs)
                     c = c.first()
@@ -947,7 +947,7 @@ def findSignatures(request, crashid):
                     if otherBucket.pk == bucket.pk:
                         continue
 
-                    if not otherBucket.pk in firstEntryPerBucketCache:
+                    if otherBucket.pk not in firstEntryPerBucketCache:
                         c = CrashEntry.objects.filter(bucket=otherBucket).first()
                         firstEntryPerBucketCache[otherBucket.pk] = c
                         if c:
@@ -1361,7 +1361,7 @@ def json_to_query(json_str):
 
         qobj = Q()
 
-        if not "op" in obj:
+        if "op" not in obj:
                 raise RuntimeError("No operator specified in query object")
 
         op = obj["op"]

--- a/server/ec2spotmanager/__init__.py
+++ b/server/ec2spotmanager/__init__.py
@@ -1,1 +1,1 @@
-from . import tasks
+from . import tasks  # noqa

--- a/server/ec2spotmanager/common/prices.py
+++ b/server/ec2spotmanager/common/prices.py
@@ -63,7 +63,7 @@ def get_spot_prices(regions, aws_key_id, aws_secret_key, instance_type, use_mult
         if use_multiprocess:
             result = result.get()
         for entry in result:
-            if not entry.region.name in prices:
+            if entry.region.name not in prices:
                 prices[entry.region.name] = {}
 
             zone = entry.availability_zone
@@ -71,7 +71,7 @@ def get_spot_prices(regions, aws_key_id, aws_secret_key, instance_type, use_mult
             if zone in zone_blacklist:
                 continue
 
-            if not zone in prices[entry.region.name]:
+            if zone not in prices[entry.region.name]:
                 prices[entry.region.name][zone] = []
 
             prices[entry.region.name][zone].append(entry.price)

--- a/server/ec2spotmanager/management/commands/start_monitoring_daemon.py
+++ b/server/ec2spotmanager/management/commands/start_monitoring_daemon.py
@@ -459,7 +459,7 @@ class Command(BaseCommand):
         instance_ids_by_region = {}
 
         for instance in instances:
-            if not instance.ec2_region in instance_ids_by_region:
+            if instance.ec2_region not in instance_ids_by_region:
                 instance_ids_by_region[instance.ec2_region] = []
             instance_ids_by_region[instance.ec2_region].append(instance.ec2_instance_id)
 
@@ -531,7 +531,7 @@ class Command(BaseCommand):
                     # Whenever we see an instance that is not in our instance list for that region,
                     # make sure it's a terminated instance because we should never have a running
                     # instance that matches the search above but is not in our database.
-                    if not boto_instance.id in instance_ids_by_region[region]:
+                    if boto_instance.id not in instance_ids_by_region[region]:
                         if not ((state_code == INSTANCE_STATE['shutting-down'] or
                                 state_code == INSTANCE_STATE['terminated'])):
 
@@ -574,7 +574,7 @@ class Command(BaseCommand):
 
         if instances_left:
             for instance in instances_left:
-                if not instance.ec2_instance_id in debug_boto_instance_ids_seen:
+                if instance.ec2_instance_id not in debug_boto_instance_ids_seen:
                     logger.info("[Pool %d] Deleting instance with EC2 ID %s from our database, "
                                 "has no corresponding machine on EC2." % (pool.id, instance.ec2_instance_id))
 

--- a/server/ec2spotmanager/management/commands/start_monitoring_daemon.py
+++ b/server/ec2spotmanager/management/commands/start_monitoring_daemon.py
@@ -19,7 +19,7 @@ from laniakea.laniakea import LaniakeaCommandLine
 
 use_multiprocess_price_fetch = False
 if use_multiprocess_price_fetch:
-    from multiprocessing import Pool, cpu_count
+    from multiprocessing import Pool, cpu_count  # noqa
 
 logger = logging.getLogger("ec2spotmanager")
 

--- a/server/ec2spotmanager/management/commands/start_monitoring_daemon.py
+++ b/server/ec2spotmanager/management/commands/start_monitoring_daemon.py
@@ -12,8 +12,7 @@ import time
 
 from ec2spotmanager.common.prices import get_spot_prices, get_price_median
 from ec2spotmanager.management.common import pid_lock_file
-from ec2spotmanager.models import PoolConfiguration, InstancePool, Instance, INSTANCE_STATE, \
-    PoolStatusEntry, POOL_STATUS_ENTRY_TYPE
+from ec2spotmanager.models import InstancePool, Instance, INSTANCE_STATE, PoolStatusEntry, POOL_STATUS_ENTRY_TYPE
 from laniakea.core.manager import Laniakea
 from laniakea.laniakea import LaniakeaCommandLine
 

--- a/server/ec2spotmanager/management/commands/start_monitoring_daemon.py
+++ b/server/ec2spotmanager/management/commands/start_monitoring_daemon.py
@@ -1,6 +1,6 @@
 import boto.ec2
 import boto.exception
-from django.conf import settings
+from django.conf import settings  # noqa
 from django.core.management import BaseCommand, CommandError
 from django.utils import timezone
 import logging

--- a/server/ec2spotmanager/management/commands/start_monitoring_daemon.py
+++ b/server/ec2spotmanager/management/commands/start_monitoring_daemon.py
@@ -195,7 +195,7 @@ class Command(BaseCommand):
                     continue
 
                 median = get_price_median(prices[region][zone])
-                if best_median == None or best_median > median:
+                if best_median is None or best_median > median:
                     best_median = median
                     best_zone = zone
                     best_region = region
@@ -346,7 +346,7 @@ class Command(BaseCommand):
                     instances[i].status_code = boto_instances[i].state_code & 255
                     instances[i].save()
 
-                    assert(instances[i].ec2_instance_id != None)
+                    assert(instances[i].ec2_instance_id is not None)
 
                     # Now that we saved the object into our database, mark the instance as updatable
                     # so our update code can pick it up and update it accordingly when it changes states

--- a/server/ec2spotmanager/migrations/0005_auto_20150520_1517.py
+++ b/server/ec2spotmanager/migrations/0005_auto_20150520_1517.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 import django.utils.timezone
-import ec2spotmanager.models
+import ec2spotmanager.models  # noqa
 
 
 class Migration(migrations.Migration):

--- a/server/ec2spotmanager/migrations/0006_auto_20150625_2050.py
+++ b/server/ec2spotmanager/migrations/0006_auto_20150625_2050.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import ec2spotmanager.models
+import ec2spotmanager.models  # noqa
 
 
 class Migration(migrations.Migration):

--- a/server/ec2spotmanager/models.py
+++ b/server/ec2spotmanager/models.py
@@ -205,7 +205,7 @@ class PoolConfiguration(models.Model):
 
         # Check regular fields, none of them is optional
         for field in self.config_fields:
-            if not field in flat_config or not flat_config[field]:
+            if field not in flat_config or not flat_config[field]:
                 missing_fields.append(field)
 
         # Most dicts/lists are optional except for the ec2_allowed_regions

--- a/server/ec2spotmanager/models.py
+++ b/server/ec2spotmanager/models.py
@@ -117,11 +117,11 @@ class PoolConfiguration(models.Model):
 
         # If we are not the top-most confifugration, recursively call flatten
         # and proceed with the configuration provided by our parent.
-        if self.parent != None:
+        if self.parent is not None:
             flat_parent_config = self.parent.flatten()
 
         for config_field in self.config_fields:
-            if getattr(self, config_field) != None:
+            if getattr(self, config_field) is not None:
                 flat_parent_config[config_field] = getattr(self, config_field)
 
         for field in self.dict_config_fields:

--- a/server/ec2spotmanager/serializers.py
+++ b/server/ec2spotmanager/serializers.py
@@ -1,4 +1,4 @@
-from django.http.response import Http404
+from django.http.response import Http404  # noqa
 from rest_framework import serializers
 
 from ec2spotmanager.models import Instance

--- a/server/ec2spotmanager/tasks.py
+++ b/server/ec2spotmanager/tasks.py
@@ -1,1 +1,1 @@
-from . import cron  # ensure cron tasks get registered
+from . import cron  # noqa ensure cron tasks get registered

--- a/server/ec2spotmanager/templatetags/datetags.py
+++ b/server/ec2spotmanager/templatetags/datetags.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from django import template
 from django.utils import timezone
 

--- a/server/ec2spotmanager/templatetags/recursetags.py
+++ b/server/ec2spotmanager/templatetags/recursetags.py
@@ -27,7 +27,7 @@ class RecurseConfigTree(template.Node):
 def recurseconfig(parser, token):
     bits = token.contents.split()
     if len(bits) != 2:
-        raise template.TemplateSyntaxError(_('%s tag requires a start configuration') % bits[0])
+        raise template.TemplateSyntaxError(_('%s tag requires a start configuration') % bits[0])  # noqa
 
     config_var = template.Variable(bits[1])
 

--- a/server/ec2spotmanager/views.py
+++ b/server/ec2spotmanager/views.py
@@ -119,7 +119,7 @@ def viewPool(request, poolid):
     last_config = pool.config
     last_config.children = []
 
-    while not cyclic and last_config.parent != None:
+    while not cyclic and last_config.parent is not None:
         last_config.parent.children = [last_config]
         last_config = last_config.parent
 

--- a/server/ec2spotmanager/views.py
+++ b/server/ec2spotmanager/views.py
@@ -6,7 +6,7 @@ from django.contrib.auth.views import logout
 from django.core.exceptions import SuspiciousOperation
 from django.core.files.base import ContentFile
 from django.db.models.aggregates import Count
-from django.http.response import Http404
+from django.http.response import Http404  # noqa
 from django.shortcuts import render, redirect, get_object_or_404
 from django.utils.timezone import now, timedelta
 import errno

--- a/server/ec2spotmanager/views.py
+++ b/server/ec2spotmanager/views.py
@@ -12,9 +12,8 @@ from django.utils.timezone import now, timedelta
 import errno
 from operator import attrgetter
 import os
-from rest_framework import viewsets, status
+from rest_framework import status
 from rest_framework.authentication import TokenAuthentication
-from rest_framework.decorators import authentication_classes, api_view
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView

--- a/server/ec2spotmanager/views.py
+++ b/server/ec2spotmanager/views.py
@@ -647,7 +647,7 @@ class UptimeChartViewAccumulated(JSONView):
 
 
 class MachineStatusViewSet(APIView):
-    authentication_classes = (TokenAuthentication,)
+    authentication_classes = (TokenAuthentication,)  # noqa
 
     def get(self, request, *args, **kwargs):
         result = {}
@@ -667,7 +667,7 @@ class MachineStatusViewSet(APIView):
 
 
 class PoolCycleView(APIView):
-    authentication_classes = (TokenAuthentication,)
+    authentication_classes = (TokenAuthentication,)  # noqa
     permission_classes = (IsAuthenticated,)
 
     def post(self, request, poolid, format=None):
@@ -683,7 +683,7 @@ class PoolCycleView(APIView):
 
 
 class PoolEnableView(APIView):
-    authentication_classes = (TokenAuthentication,)
+    authentication_classes = (TokenAuthentication,)  # noqa
     permission_classes = (IsAuthenticated,)
 
     def post(self, request, poolid, format=None):
@@ -700,7 +700,7 @@ class PoolEnableView(APIView):
 
 
 class PoolDisableView(APIView):
-    authentication_classes = (TokenAuthentication,)
+    authentication_classes = (TokenAuthentication,)  # noqa
     permission_classes = (IsAuthenticated,)
 
     def post(self, request, poolid, format=None):

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -24,7 +24,7 @@ sys.path += [FTB_PATH]
 SECRET_FILE = os.path.join(BASE_DIR, "settings.secret")
 try:
     SECRET_KEY = open(SECRET_FILE).read().strip()
-except:
+except Exception:
     try:
         with open(SECRET_FILE, 'w') as f:
             import random

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/1.6/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 import sys
-from django.conf import global_settings
+from django.conf import global_settings  # noqa
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 FTB_PATH = os.path.abspath(os.path.join(BASE_DIR, ".."))

--- a/server/server/settings_nondebug.py
+++ b/server/server/settings_nondebug.py
@@ -1,2 +1,2 @@
-from .settings import *
+from .settings import *  # noqa
 DEBUG = False

--- a/server/server/wsgi.py
+++ b/server/server/wsgi.py
@@ -10,5 +10,5 @@ https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
 import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.settings")
 
-from django.core.wsgi import get_wsgi_application
+from django.core.wsgi import get_wsgi_application  # noqa
 application = get_wsgi_application()


### PR DESCRIPTION
Here's the second wave of flake8 changes - this also activates CI integration on Travis.

Notes:
* `==` got replaced by `is`, and `!=` by `is not` in rev 06509d8df5c3bdd3c827f44e8e74999e1adda4de
* Some seemingly unused variables were removed by rev 632481e1bb70591dd92fb48f8b3bebdd1803e9d5
* Removed seemingly unnecessary imports. Hopefully I did not remove anything essential.
* The linters seem unable to follow certain package-level imports. It may be an issue with the current folder structure, but I ignored these import lines for now from the linter.
  * It may also be related to flake8 not reacting well to django's folder structure in general
* I'm not sure if the redefinition of existing classes (e.g. `response_t` in rev a4d8fdbaecaff8d70c4fb38defe0753609b1d704) was intentional, so ignored the lines for now

There were some other portions that I was not sure what to change, so I just ignored them.

The error count is now zero, with Travis integration added to enforce this.