### PR TITLE
Reporter clean-up & --download-all

### DIFF
--- a/CovReporter/CovReporter.py
+++ b/CovReporter/CovReporter.py
@@ -23,7 +23,6 @@ from __future__ import print_function
 import argparse
 import json
 import os
-import requests
 import sys
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -123,10 +122,7 @@ class CovReporter(Reporter):
         data["description"] = description
         data.update(version)
 
-        response = requests.post(url, data, headers=dict(Authorization="Token %s" % self.serverAuthToken))
-
-        if response.status_code != requests.codes["created"]:
-            raise Reporter.serverError(response)
+        self.post(url, data)
 
     @staticmethod
     def preprocess_coverage_data(coverage):

--- a/EC2Reporter/EC2Reporter.py
+++ b/EC2Reporter/EC2Reporter.py
@@ -21,13 +21,14 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from __future__ import print_function
 
 import argparse
-from fasteners import InterProcessLock
 import functools
 import os
 import random
-import requests
 import sys
 import time
+
+from fasteners import InterProcessLock
+import requests
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 FTB_PATH = os.path.abspath(os.path.join(BASE_DIR, ".."))
@@ -64,10 +65,7 @@ class EC2Reporter(Reporter):
         data["client"] = self.clientId
         data["status_data"] = text
 
-        response = requests.post(url, data, headers=dict(Authorization="Token %s" % self.serverAuthToken))
-
-        if response.status_code != requests.codes["created"]:
-            raise Reporter.serverError(response)
+        self.post(url, data)
 
     @remote_checks
     def cycle(self, poolid):
@@ -80,10 +78,7 @@ class EC2Reporter(Reporter):
         url = "%s://%s:%s/ec2spotmanager/rest/pool/%s/cycle/" % (self.serverProtocol, self.serverHost, self.serverPort,
                                                                  poolid)
 
-        response = requests.post(url, {}, headers=dict(Authorization="Token %s" % self.serverAuthToken))
-
-        if response.status_code != requests.codes["ok"]:
-            raise Reporter.serverError(response)
+        self.post(url, {}, expected=requests.codes["ok"])
 
     @remote_checks
     def disable(self, poolid):
@@ -96,10 +91,7 @@ class EC2Reporter(Reporter):
         url = "%s://%s:%s/ec2spotmanager/rest/pool/%s/disable/" % (self.serverProtocol, self.serverHost,
                                                                    self.serverPort, poolid)
 
-        response = requests.post(url, {}, headers=dict(Authorization="Token %s" % self.serverAuthToken))
-
-        if response.status_code != requests.codes["ok"]:
-            raise Reporter.serverError(response)
+        self.post(url, {}, expected=requests.codes["ok"])
 
     @remote_checks
     def enable(self, poolid):
@@ -112,10 +104,7 @@ class EC2Reporter(Reporter):
         url = "%s://%s:%s/ec2spotmanager/rest/pool/%s/enable/" % (self.serverProtocol, self.serverHost,
                                                                   self.serverPort, poolid)
 
-        response = requests.post(url, {}, headers=dict(Authorization="Token %s" % self.serverAuthToken))
-
-        if response.status_code != requests.codes["ok"]:
-            raise Reporter.serverError(response)
+        self.post(url, {}, expected=requests.codes["ok"])
 
 
 def main(argv=None):

--- a/EC2Reporter/test_EC2Reporter.py
+++ b/EC2Reporter/test_EC2Reporter.py
@@ -1,0 +1,126 @@
+from __future__ import absolute_import
+import json
+import os
+import platform
+import time
+import zipfile
+
+import pytest
+import requests
+from django.utils import timezone
+from six.moves.urllib.parse import urlsplit
+
+from EC2Reporter.EC2Reporter import EC2Reporter, main
+from ec2spotmanager.models import Instance, InstancePool
+from ec2spotmanager.tests import TestCase as utils
+
+
+pytest_plugins = 'server.tests'
+
+
+def test_ec2reporter_help(capsys):
+    '''Test that help prints without throwing'''
+    with pytest.raises(SystemExit):
+        main()
+    _, err = capsys.readouterr()
+    assert err.startswith('usage: ')
+
+
+def test_ec2reporter_report(live_server, tmpdir, fm_user, monkeypatch):
+    '''Test report submission'''
+    monkeypatch.setattr(os.path, 'expanduser', lambda path: tmpdir.strpath)  # ensure fuzzmanager config is not used
+    monkeypatch.setattr(time, 'sleep', lambda t: None)
+
+    # create an instance
+    host = utils.create_instance('host1')
+
+    # create a reporter
+    url = urlsplit(live_server.url)
+    reporter = EC2Reporter(sigCacheDir=tmpdir.mkdir('sigcache').strpath,
+                           serverHost=url.hostname,
+                           serverPort=url.port,
+                           serverProtocol=url.scheme,
+                           serverAuthToken=fm_user.token,
+                           clientId='host1')
+
+    reporter.report('data')
+    host = Instance.objects.get(pk=host.pk)  # re-read
+    assert host.status_data == 'data'
+
+    reporter.report(None)
+    host = Instance.objects.get(pk=host.pk)  # re-read
+    assert host.status_data is None
+
+    reporter = EC2Reporter(sigCacheDir=tmpdir.join('sigcache').strpath,
+                           serverHost=url.hostname,
+                           serverPort=url.port,
+                           serverProtocol=url.scheme,
+                           serverAuthToken=fm_user.token,
+                           clientId='host2')
+
+    with pytest.raises(RuntimeError, message="Server unexpectedly responded with status code 404: Not found"):
+        reporter.report('data')
+
+
+def test_ec2reporter_xable(live_server, tmpdir, fm_user, monkeypatch):
+    '''Test EC2Reporter enable/disable'''
+    monkeypatch.setattr(os.path, 'expanduser', lambda path: tmpdir.strpath)  # ensure fuzzmanager config is not used
+    monkeypatch.setattr(time, 'sleep', lambda t: None)
+
+    config = utils.create_config('testconfig')
+    pool = utils.create_pool(config)
+
+    # create a reporter
+    url = urlsplit(live_server.url)
+    reporter = EC2Reporter(sigCacheDir=tmpdir.mkdir('sigcache').strpath,
+                           serverHost=url.hostname,
+                           serverPort=url.port,
+                           serverProtocol=url.scheme,
+                           serverAuthToken=fm_user.token,
+                           clientId='host1')
+
+    reporter.enable(pool.pk)
+    pool = InstancePool.objects.get(pk=pool.pk)  # re-read
+    assert pool.isEnabled
+
+    with pytest.raises(RuntimeError, message="Server unexpectedly responded with status code 405: Not acceptable"):
+        reporter.enable(pool.pk)
+    pool = InstancePool.objects.get(pk=pool.pk)  # re-read
+    assert pool.isEnabled
+
+    reporter.disable(pool.pk)
+    pool = InstancePool.objects.get(pk=pool.pk)  # re-read
+    assert not pool.isEnabled
+
+    with pytest.raises(RuntimeError, message="Server unexpectedly responded with status code 405: Not acceptable"):
+        reporter.disable(pool.pk)
+    pool = InstancePool.objects.get(pk=pool.pk)  # re-read
+    assert not pool.isEnabled
+
+
+def test_ec2reporter_cycle(live_server, tmpdir, fm_user, monkeypatch):
+    """Test EC2Reporter cycle"""
+    monkeypatch.setattr(os.path, 'expanduser', lambda path: tmpdir.strpath)  # ensure fuzzmanager config is not used
+    monkeypatch.setattr(time, 'sleep', lambda t: None)
+
+    config = utils.create_config('testconfig')
+    pool = utils.create_pool(config, last_cycled=timezone.now())
+
+    # create a reporter
+    url = urlsplit(live_server.url)
+    reporter = EC2Reporter(sigCacheDir=tmpdir.mkdir('sigcache').strpath,
+                           serverHost=url.hostname,
+                           serverPort=url.port,
+                           serverProtocol=url.scheme,
+                           serverAuthToken=fm_user.token,
+                           clientId='host1')
+
+    with pytest.raises(RuntimeError, message="Server unexpectedly responded with status code 405: Not acceptable"):
+        reporter.cycle(pool.pk)
+
+    pool.isEnabled = True
+    pool.save()
+    reporter.cycle(pool.pk)
+    pool = InstancePool.objects.get(pk=pool.pk)  # re-read
+    assert pool.isEnabled
+    assert pool.last_cycled is None


### PR DESCRIPTION
- wrap requests.get/requests.post usage for easier authentication and retrying on 5xx errors on all calls
- use a requests.Session for connection-reuse
- add tests for EC2Reporter
- use crash ID for download filename
- add a `--download-all` option, which takes a signature ID and downloads all testcases for that signature