### PR TITLE
Fix #442: Crash address can cause ValueError: invalid literal for int in some cases.

### DIFF
--- a/server/crashmanager/models.py
+++ b/server/crashmanager/models.py
@@ -240,7 +240,7 @@ class CrashEntry(models.Model):
         self.cachedCrashInfo = None
         crashInfo = self.getCrashInfo()
         if crashInfo.crashAddress is not None:
-            self.crashAddress = hex(crashInfo.crashAddress)
+            self.crashAddress = '0x%x' % crashInfo.crashAddress
         self.shortSignature = crashInfo.createShortSignature()
 
         # If the entry has a bucket, check if it still fits into

--- a/server/crashmanager/serializers.py
+++ b/server/crashmanager/serializers.py
@@ -77,7 +77,7 @@ class CrashEntrySerializer(serializers.ModelSerializer):
 
         # Populate certain fields here from the CrashInfo object we just got
         if crashInfo.crashAddress is not None:
-            attrs['crashAddress'] = hex(crashInfo.crashAddress)
+            attrs['crashAddress'] = '0x%x' % crashInfo.crashAddress
         attrs['shortSignature'] = crashInfo.createShortSignature()
 
         # If a testcase is supplied, create a testcase object and store it


### PR DESCRIPTION
In Python 2, calling `hex()` on a `long` value produces a string like '0x123L' which `int(.., 16)` can't parse.
Also add test for submitting the log @nth10sd was using in #442.

ref: [PEP 237](https://www.python.org/dev/peps/pep-0237/)