### PR TITLE
Add support for line-endings in EC2 user_data.

### DIFF
--- a/server/crashmanager/static/css/ec2spotmanager.css
+++ b/server/crashmanager/static/css/ec2spotmanager.css
@@ -3,3 +3,23 @@
   height: 500px;
   background: #fcfcfc;
 }
+
+.ec2-radio-group {
+  margin: 0;
+}
+
+.ec2-radio-group > legend {
+  border: 0;
+  margin-bottom: 5px;
+  font-size: 100%;
+  font-weight: bold;
+}
+
+.ec2-radio-group > label {
+  margin: 0 12px;
+  font-weight: normal;
+}
+
+.ec2-radio-group > input {
+  margin: 0;
+}

--- a/server/ec2spotmanager/templates/config/edit.html
+++ b/server/ec2spotmanager/templates/config/edit.html
@@ -89,6 +89,13 @@
                 spellcheck='false'>{{ config.ec2_userdata|default:"" }}</textarea>
       <br/>
 
+      <fieldset class="ec2-radio-group">
+      <legend>EC2 Userdata Script Line Endings</legend>
+      <label><input type="radio" name="ec2_userdata_ff" value="unix"{% if userdata_ff == 'unix' %} checked="checked"{% endif %}> Unix</label>
+      <label><input type="radio" name="ec2_userdata_ff" value="dos"{% if userdata_ff == 'dos' %} checked="checked"{% endif %}> DOS</label>
+      </fieldset>
+      <br/>
+
       <label for="id_ec2_userdata_macros">EC2 Userdata Macros</label><br/>
       <input id="id_ec2_userdata_macros" class="form-control" name="ec2_userdata_macros" type="text"
              value="{{ config.ec2_userdata_macros_dict|dictcsv }}">


### PR DESCRIPTION
EC2 user_data can be either Unix or DOS line-endings. We should support both, since Windows can also use user_data scripts.