### PR TITLE
Remove source hash from rust symbols in backtrace.

### DIFF
--- a/FTB/Signatures/test_CrashInfo.py
+++ b/FTB/Signatures/test_CrashInfo.py
@@ -640,10 +640,10 @@ OS|Windows NT|10.0.14393
 CPU|amd64|family 6 model 94 stepping 3|4
 GPU|||
 Crash|EXCEPTION_ILLEGAL_INSTRUCTION|0x7ffc41f2f276|36
-36|0|xul.dll|std::panicking::rust_panic_with_hook|git:github.com/rust-lang/rust:src/libstd/panicking.rs:0ade339411587887bf01bcfa2e9ae4414c8900d4|555|0x41
-36|1|xul.dll|std::panicking::begin_panic<&str>|git:github.com/rust-lang/rust:src/libstd/panicking.rs:0ade339411587887bf01bcfa2e9ae4414c8900d4|511|0x12
-36|2|xul.dll|atomic_refcell::AtomicBorrowRef::do_panic|hg:hg.mozilla.org/mozilla-central:third_party/rust/atomic_refcell/src/lib.rs:37b95547f0d2|161|0x18
-36|3|xul.dll|style::values::specified::color::{{impl}}::to_computed_value|hg:hg.mozilla.org/mozilla-central:servo/components/style/values/specified/color.rs:37b95547f0d2|288|0xc
+36|0|xul.dll|std::panicking::rust_panic_with_hook::h4d68aac0b79bfb98|git:github.com/rust-lang/rust:src/libstd/panicking.rs:0ade339411587887bf01bcfa2e9ae4414c8900d4|555|0x41
+36|1|xul.dll|std::panicking::begin_panic<&str>::h4d68aac0b79bfb98|git:github.com/rust-lang/rust:src/libstd/panicking.rs:0ade339411587887bf01bcfa2e9ae4414c8900d4|511|0x12
+36|2|xul.dll|atomic_refcell::AtomicBorrowRef::do_panic::h4d68aac0b79bfb98|hg:hg.mozilla.org/mozilla-central:third_party/rust/atomic_refcell/src/lib.rs:37b95547f0d2|161|0x18
+36|3|xul.dll|style::values::specified::color::{{impl}}::to_computed_value::h4d68aac0b79bfb98|hg:hg.mozilla.org/mozilla-central:servo/components/style/values/specified/color.rs:37b95547f0d2|288|0xc
 0|0|ntdll.dll|AslpFilePartialViewFree|||0x36808
 0|1|||||0xcd07ffd740
 0|2|KERNELBASE.dll|FSPErrorMessages::CMessageHashVectorBuilder::GetEndIndexHash(unsigned short const *)|||0x38


### PR DESCRIPTION
This is happening now with Minidump crashes, but I made it operate on all `CrashInfo` objects parsed using `fromRawCrashData()` since I don't know if we will see this happen from other sources in the future (ASan especially).