### PR TITLE
Fix CovManager test failure seen in Travis CI:

### DIFF
--- a/server/covmanager/migrations/0002_increase_collection_filename_length.py
+++ b/server/covmanager/migrations/0002_increase_collection_filename_length.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import django.core.files.storage
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('covmanager', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='collectionfile',
+            name='file',
+            field=models.FileField(max_length=255, storage=django.core.files.storage.FileSystemStorage(location=None),
+                                   upload_to=b'coverage'),
+        ),
+    ]

--- a/server/covmanager/models.py
+++ b/server/covmanager/models.py
@@ -28,6 +28,7 @@ class Repository(models.Model):
 
 class CollectionFile(models.Model):
     file = models.FileField(storage=FileSystemStorage(location=getattr(settings, 'COV_STORAGE', None)),
+                            max_length=255,
                             upload_to="coverage")
     format = models.IntegerField(default=0)
 


### PR DESCRIPTION
    django.core.exceptions.SuspiciousFileOperation: Storage can not find an available filename for "...".  Please make sure that the corresponding file field allows sufficient "max_length".

The FileField used default `max_length` of 100, which is too low for the working directory provided by Travis CI. Increase it to 255 which is the typical filesystem max.