### PR TITLE
Update server requirements to latest versions.

### DIFF
--- a/server/crashmanager/serializers.py
+++ b/server/crashmanager/serializers.py
@@ -111,7 +111,7 @@ class CrashEntrySerializer(serializers.ModelSerializer):
 
 
 class BucketSerializer(serializers.ModelSerializer):
-    bug = serializers.CharField(source='bug.externalId')
+    bug = serializers.CharField(source='bug.externalId', default=None)
     # write_only here means don't try to read it automatically in super().to_representation()
     # size and best_quality are annotations, so must be set manually
     size = serializers.IntegerField(write_only=True)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,18 +1,48 @@
+amqp==2.3.2
+appdirs==1.4.3
+astroid==1.6.4
+atomicwrites==1.1.5
+attrs==18.1.0
+backports.functools-lru-cache==1.5; python_version == '2.7'
+billiard==3.5.0.3
 boto==2.48.0
-celery==4.1.0
-Django==1.11.5
-django-chartjs==1.2
-djangorestframework==3.6.4
+celery==4.1.1
+certifi==2018.4.16
+chardet==3.0.4
+configparser==3.5.0; python_version == '2.7'
+coverage==4.5.1
+Django==1.11.13
+django-chartjs==1.3
+djangorestframework==3.8.2
+enum34==1.1.6; python_version == '2.7'
 fasteners==0.14.1
 flake8==3.5.0
+funcsigs==1.0.2; python_version == '2.7'
+futures==3.2.0; python_version == '2.7'
+idna==2.6
+isort==4.3.4
+kombu==4.2.1
 laniakea==0.8
-numpy==1.13.3
-pylint==1.8.3
-pytest==3.4.2
-requests==2.18.4
-six==1.11.0
-pytest-flake8==1.0.0
-pytest-pylint==0.9.0
+lazy-object-proxy==1.3.1
+mccabe==0.6.1
+monotonic==1.5
+more-itertools==4.2.0
+numpy==1.14.3
+pluggy==0.6.0
+py==1.5.3
+pycodestyle==2.3.1
+pyflakes==1.6.0
+pylint==1.9.1
+pytest==3.6.1
 pytest-cov==2.5.1
-pytest-django==3.1.2
+pytest-django==3.2.1
+pytest-flake8==1.0.1
+pytest-pylint==0.9.0
 pytest-pythonpath==0.7.2
+pytz==2018.4
+requests==2.18.4
+singledispatch==3.4.0.3; python_version == '2.7'
+six==1.11.0
+urllib3==1.22
+vine==1.1.4
+wrapt==1.10.11


### PR DESCRIPTION
This updates all requirements to latest versions (except Django which is on the 1.11 LTS branch). I've pinned versions for all dependencies to make testing in a virtualenv and on Travis CI more consistent. I'll add `server/setup.py` in another change with minimal dependencies to make local installation easier.