### PR TITLE
Add support for using Redis.

### DIFF
--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -276,6 +276,9 @@ USERDATA_STORAGE = os.path.join(BASE_DIR)
 # This is the directory where signatures.zip will be stored
 SIGNATURE_STORAGE = os.path.join(BASE_DIR)
 
+# Redis configuration
+# USE_REDIS = True
+
 # Celery configuration
 # USE_CELERY = True
 # CELERY_ACCEPT_CONTENT = ['json']


### PR DESCRIPTION
Redis is used to blacklist AWS regions where we fail to spawn instances, and to cache AMI name to ID resolution.