### PR TITLE
Don't crash if $pc is not readable

### DIFF
--- a/FTB/Signatures/CrashInfo.py
+++ b/FTB/Signatures/CrashInfo.py
@@ -948,6 +948,8 @@ class GDBCrashInfo(CrashInfo):
         if self.crashInstruction is not None:
             # Remove any leading/trailing whitespaces
             self.crashInstruction = self.crashInstruction.strip()
+            if 'Error in sourced command file' in self.crashInstruction:
+                self.crashInstruction = None
 
         # If we have no crash address but the instruction, try to calculate the crash address
         if self.crashAddress is None and self.crashInstruction is not None:


### PR DESCRIPTION
Sometimes the program counter points to a non-readable memory address after a crash. When we run the `gdb_cmds.txt` file in funfuzz, commands like `x/8i $pc` will fail. I'm not sure if this is the right solution, but I just check for the text 'Error in sourced command file' in the `crashInstruction` variable and set the instruction to `None` so it's ignored. I tested this locally and it seems to work.