### PR TITLE
Allow non-ASCII in crash logs, when tested against a signature.

### DIFF
--- a/FTB/Signatures/Matchers.py
+++ b/FTB/Signatures/Matchers.py
@@ -61,6 +61,11 @@ class StringMatch():
                     raise RuntimeError("Unknown match operator specified: %s" % matchType)
 
     def matches(self, val):
+        if isinstance(val, bytes):
+            # If the input is not already unicode, try to interpret it as UTF-8
+            # If there are errors, replace them with U+FFFD so we neither raise nor false positive.
+            val = val.decode("utf-8", errors="replace")
+
         if self.isPCRE:
             return self.compiledValue.search(val) is not None
         else:

--- a/FTB/Signatures/test_CrashSignature.py
+++ b/FTB/Signatures/test_CrashSignature.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 '''
 Created on Oct 9, 2014
 
@@ -695,6 +696,14 @@ class SignatureGenerationTSanRaceTest(unittest.TestCase):
                 if symptom.output.value == stringMatchVal:
                     found = True
             self.assertTrue(found, msg="Couldn't find OutputSymptom with value '%s'" % stringMatchVal)
+
+
+class SignatureMatchWithUnicode(unittest.TestCase):
+    def runTest(self):
+        config = ProgramConfiguration('test', 'x86-64', 'linux')
+        crashInfo = CrashInfo.fromRawCrashData(["(Â«f => (generator.throw(f))Â», Â«undefinedÂ»)"], [], config)
+        testSignature = CrashSignature('{"symptoms": [{"src": "stdout", "type": "output", "value": "x"}]}')
+        self.assertFalse(testSignature.matches(crashInfo))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If the input is not already unicode, try to interpret it as UTF-8. If there are errors, replace them with U+FFFD so we neither raise nor generate a false positive match.

Fixes #501.