### PR TITLE
Sort pools by name rather than ID

### DIFF
--- a/server/ec2spotmanager/views.py
+++ b/server/ec2spotmanager/views.py
@@ -40,7 +40,7 @@ def pools(request):
     filters = {}
     isSearch = True
 
-    entries = InstancePool.objects.annotate(size=Count('instance')).order_by('-id')
+    entries = InstancePool.objects.annotate(size=Count('instance')).order_by('config__name')
 
     # These are all keys that are allowed for exact filtering
     exactFilterKeys = [


### PR DESCRIPTION
All views referencing the pool list would likely benefit by sorting on config.name rather than id.