### PR TITLE
[EC2SpotManager] Add checkboxes to overwrite parent in PoolConfigurations.

### DIFF
--- a/server/crashmanager/static/css/ec2spotmanager.css
+++ b/server/crashmanager/static/css/ec2spotmanager.css
@@ -23,3 +23,7 @@
 .ec2-radio-group > input {
   margin: 0;
 }
+
+label.no-bold {
+  font-weight: normal;
+}

--- a/server/ec2spotmanager/templates/config/edit.html
+++ b/server/ec2spotmanager/templates/config/edit.html
@@ -62,11 +62,17 @@
       <label for="id_ec2_security_groups">EC2 Security Groups</label><br/>
       <input id="id_ec2_security_groups" class="form-control" name="ec2_security_groups" type="text"
              value="{{ config.ec2_security_groups_list|listcsv }}">
+      <input id="id_ec2_security_groups_override" name="ec2_security_groups_override" type="checkbox"
+             {% if config.ec2_security_groups_override %}checked{% endif %} title="Overwrite parent config">
+      <label class="no-bold" for="id_ec2_security_groups_override">Overwrite parent config</label>
       <br/>
 
       <label for="id_ec2_instance_types">EC2 Instance Types</label><br/>
       <input id="id_ec2_instance_types" class="form-control" name="ec2_instance_types" type="text"
              value="{{ config.ec2_instance_types_list|listcsv }}">
+      <input id="id_ec2_instance_types_override" name="ec2_instance_types_override" type="checkbox"
+             {% if config.ec2_instance_types_override %}checked{% endif %} title="Overwrite parent config">
+      <label class="no-bold" for="id_ec2_instance_types_override">Overwrite parent config</label>
       <br/>
 
       <label for="id_ec2_image_name">EC2 Image Name</label><br/>
@@ -89,11 +95,17 @@
       <label for="id_ec2_userdata_macros">EC2 Userdata Macros</label><br/>
       <input id="id_ec2_userdata_macros" class="form-control" name="ec2_userdata_macros" type="text"
              value="{{ config.ec2_userdata_macros_dict|dictcsv }}">
+      <input id="id_ec2_userdata_macros_override" name="ec2_userdata_macros_override" type="checkbox"
+             {% if config.ec2_userdata_macros_override %}checked{% endif %} title="Overwrite parent config">
+      <label class="no-bold" for="id_ec2_userdata_macros_override">Overwrite parent config</label>
       <br/>
 
       <label for="id_ec2_allowed_regions">EC2 Allowed Regions</label><br/>
       <input id="id_ec2_allowed_regions" class="form-control" name="ec2_allowed_regions" type="text"
              value="{{ config.ec2_allowed_regions_list|listcsv }}">
+      <input id="id_ec2_allowed_regions_override" name="ec2_allowed_regions_override" type="checkbox"
+             {% if config.ec2_allowed_regions_override %}checked{% endif %} title="Overwrite parent config">
+      <label class="no-bold" for="id_ec2_allowed_regions_override">Overwrite parent config</label>
       <br/>
 
       <label for="id_ec2_max_price">EC2 Maximum Price (per core)</label><br/>
@@ -104,11 +116,17 @@
       <label for="id_ec2_tags">EC2 Additional Tags</label><br/>
       <input id="id_ec2_tags" class="form-control" name="ec2_tags" type="text"
              value="{{ config.ec2_tags_dict|dictcsv }}">
+      <input id="id_ec2_tags_override" name="ec2_tags_override" type="checkbox"
+             {% if config.ec2_tags_override %}checked{% endif %} title="Overwrite parent config">
+      <label class="no-bold" for="id_ec2_tags_override">Overwrite parent config</label>
       <br/>
 
       <label for="id_ec2_raw_config">Additional Raw Configuration</label><br/>
       <input id="id_ec2_raw_config" class="form-control" name="ec2_raw_config" type="text"
              value="{{ config.ec2_raw_config_dict|dictcsv }}">
+      <input id="id_ec2_raw_config_override" name="ec2_raw_config_override" type="checkbox"
+             {% if config.ec2_raw_config_override %}checked{% endif %} title="Overwrite parent config">
+      <label class="no-bold" for="id_ec2_raw_config_override">Overwrite parent config</label>
       <br/>
 
       <input type="submit" name="submit_save" value="Save" class="btn btn-danger"/>

--- a/server/ec2spotmanager/templates/config/view.html
+++ b/server/ec2spotmanager/templates/config/view.html
@@ -23,15 +23,15 @@
 		<tr><td>Size (cores)</td><td>{% if config.size %} {{ config.size }} {% else %} Not specified {% endif %}</td></tr>
 		<tr><td>Cycle Interval</td><td>{% if config.cycle_interval %} {{ config.cycle_interval }} seconds {% else %} Not specified {% endif %}</td></tr>
 		<tr><td>EC2 Key Name</td><td>{% if config.ec2_key_name %} {{ config.ec2_key_name }} {% else %} Not specified {% endif %}</td></tr>
-		<tr><td>EC2 Security Groups</td><td>{% if config.ec2_security_groups %} {{ config.ec2_security_groups|jsonparse|listcsv }} {% else %} Not specified {% endif %}</td></tr>
-		<tr><td>EC2 Instance Types</td><td>{% if config.ec2_instance_types %} {{ config.ec2_instance_types|jsonparse|listcsv }} {% else %} Not specified {% endif %}</td></tr>
+		<tr><td>EC2 Security Groups</td><td>{% if config.ec2_security_groups_list %} {{ config.ec2_security_groups_list|listcsv }} {% else %} Not specified {% endif %}{% if config.ec2_security_groups_override %} (overwrite parent) {% endif %}</td></tr>
+		<tr><td>EC2 Instance Types</td><td>{% if config.ec2_instance_types_list %} {{ config.ec2_instance_types_list|listcsv }} {% else %} Not specified {% endif %}{% if config.ec2_instance_types_override %} (overwrite parent) {% endif %}</td></tr>
 		<tr><td>EC2 Image Name</td><td>{% if config.ec2_image_name %} {{ config.ec2_image_name }} {% else %} Not specified {% endif %}</td></tr>
 		<tr><td>EC2 Userdata File</td><td>{% if config.ec2_userdata_file %} {{ config.ec2_userdata_file }} {% else %} Not specified {% endif %}</td></tr>
-		<tr><td>EC2 Userdata Macros</td><td>{% if config.ec2_userdata_macros %} {{ config.ec2_userdata_macros|jsonparse|dictcsv }} {% else %} Not specified {% endif %}</td></tr>
-		<tr><td>EC2 Allowed Regions</td><td>{% if config.ec2_allowed_regions %} {{ config.ec2_allowed_regions|jsonparse|listcsv }} {% else %} Not specified {% endif %}</td></tr>
+		<tr><td>EC2 Userdata Macros</td><td>{% if config.ec2_userdata_macros_dict %} {{ config.ec2_userdata_macros_dict|dictcsv }} {% else %} Not specified {% endif %}{% if config.ec2_userdata_macros_override %} (overwrite parent) {% endif %}</td></tr>
+		<tr><td>EC2 Allowed Regions</td><td>{% if config.ec2_allowed_regions_list %} {{ config.ec2_allowed_regions_list|listcsv }} {% else %} Not specified {% endif %}{% if config.ec2_allowed_regions_override %} (overwrite parent) {% endif %}</td></tr>
 		<tr><td>EC2 Maximum Price (per core)</td><td>{% if config.ec2_max_price %} {{ config.ec2_max_price }} USD {% else %} Not specified {% endif %}</td></tr>
-		<tr><td>EC2 Additional Tags</td><td>{% if config.ec2_tags %} {{ config.ec2_tags|jsonparse|dictcsv }} {% else %} Not specified {% endif %}</td></tr>
-		<tr><td>EC2 Additional Raw Configuration</td><td>{% if config.ec2_raw_config %} {{ config.ec2_raw_config|jsonparse|dictcsv }} {% else %} Not specified {% endif %}</td></tr>
+		<tr><td>EC2 Additional Tags</td><td>{% if config.ec2_tags_dict %} {{ config.ec2_tags_dict|dictcsv }} {% else %} Not specified {% endif %}{% if config.ec2_tags_override %} (overwrite parent) {% endif %}</td></tr>
+		<tr><td>EC2 Additional Raw Configuration</td><td>{% if config.ec2_raw_config_dict %} {{ config.ec2_raw_config_dict|dictcsv }} {% else %} Not specified {% endif %}{% if config.ec2_raw_config_override %} (overwrite parent) {% endif %}</td></tr>
 	</table>
 </div>
 {% endblock body_content %}

--- a/server/ec2spotmanager/views.py
+++ b/server/ec2spotmanager/views.py
@@ -283,9 +283,9 @@ def viewConfigs(request):
 def viewConfig(request, configid):
     config = get_object_or_404(PoolConfiguration, pk=configid)
 
-    data = {'config': config}
+    config.deserializeFields()
 
-    return render(request, 'config/view.html', data)
+    return render(request, 'config/view.html', {'config': config})
 
 
 def __handleConfigPOST(request, config):
@@ -326,33 +326,39 @@ def __handleConfigPOST(request, config):
         config.ec2_allowed_regions_list = [x.strip() for x in request.POST['ec2_allowed_regions'].split(',')]
     else:
         config.ec2_allowed_regions_list = None
+    config.ec2_allowed_regions_override = request.POST.get('ec2_allowed_regions_override', 'off') == 'on'
 
     if request.POST['ec2_security_groups']:
         config.ec2_security_groups_list = [x.strip() for x in request.POST['ec2_security_groups'].split(',')]
     else:
         config.ec2_security_groups_list = None
+    config.ec2_security_groups_override = request.POST.get('ec2_security_groups_override', 'off') == 'on'
 
     if request.POST['ec2_instance_types']:
         config.ec2_instance_types_list = [x.strip() for x in request.POST['ec2_instance_types'].split(',')]
     else:
         config.ec2_instance_types_list = None
+    config.ec2_instance_types_override = request.POST.get('ec2_instance_types_override', 'off') == 'on'
 
     if request.POST['ec2_userdata_macros']:
         config.ec2_userdata_macros_dict = dict(
             y.split('=', 1) for y in [x.strip() for x in request.POST['ec2_userdata_macros'].split(',')])
     else:
         config.ec2_userdata_macros_dict = None
+    config.ec2_userdata_macros_override = request.POST.get('ec2_userdata_macros_override', 'off') == 'on'
 
     if request.POST['ec2_tags']:
         config.ec2_tags_dict = dict(y.split('=', 1) for y in [x.strip() for x in request.POST['ec2_tags'].split(',')])
     else:
         config.ec2_tags_dict = None
+    config.ec2_tags_override = request.POST.get('ec2_tags_override', 'off') == 'on'
 
     if request.POST['ec2_raw_config']:
         config.ec2_raw_config_dict = dict(
             y.split('=', 1) for y in [x.strip() for x in request.POST['ec2_raw_config'].split(',')])
     else:
         config.ec2_raw_config_dict = None
+    config.ec2_raw_config_override = request.POST.get('ec2_raw_config_override', 'off') == 'on'
 
     # Ensure we have a primary key before attempting to store files
     config.save()


### PR DESCRIPTION
This allows breaking inheritance for list/dict on a per-field level as described in #466.

![image](https://user-images.githubusercontent.com/4673461/44731811-fd46a980-aab1-11e8-9356-728d3aef9481.png)
