### PR TITLE
[FTB] Support backslash in assertion message paths

### DIFF
--- a/FTB/AssertionHelper.py
+++ b/FTB/AssertionHelper.py
@@ -247,7 +247,7 @@ def escapePattern(msg):
 
     escapedStr = msg
 
-    activeChars = ["\\", "[", "]", "{", "}", "(", ")", "*", "+", "-", "?", "^", "$", ".", "|"]
+    activeChars = ["\\", "[", "]", "{", "}", "(", ")", "*", "+", "?", "^", "$", ".", "|"]
 
     for activeChar in activeChars:
         escapedStr = escapedStr.replace(activeChar, "\\" + activeChar)

--- a/FTB/Signatures/CrashInfo.py
+++ b/FTB/Signatures/CrashInfo.py
@@ -34,7 +34,7 @@ from FTB.Signatures.CrashSignature import CrashSignature
 
 
 @six.add_metaclass(ABCMeta)
-class CrashInfo():
+class CrashInfo(object):
     '''
     Abstract base class that provides a method to instantiate the right sub class.
     It also supports generating a CrashSignature based on the stored information.

--- a/FTB/Signatures/CrashSignature.py
+++ b/FTB/Signatures/CrashSignature.py
@@ -23,7 +23,7 @@ from FTB.Signatures.Symptom import Symptom, TestcaseSymptom, StackFramesSymptom,
     OutputSymptom
 
 
-class CrashSignature():
+class CrashSignature(object):
     def __init__(self, rawSignature):
         '''
         Constructor

--- a/FTB/Signatures/Symptom.py
+++ b/FTB/Signatures/Symptom.py
@@ -27,7 +27,7 @@ from FTB.Signatures.Matchers import StringMatch, NumberMatch
 
 
 @six.add_metaclass(ABCMeta)
-class Symptom():
+class Symptom(object):
     '''
     Abstract base class that provides a method to instantiate the right sub class.
     It also supports generating a CrashSignature based on the stored information.
@@ -124,8 +124,9 @@ class OutputSymptom(Symptom):
         else:
             checkedOutput = crashInfo.rawCrashData
 
+        windowsSlashWorkaround = crashInfo.configuration.os == "windows"
         for line in reversed(checkedOutput):
-            if self.output.matches(line):
+            if self.output.matches(line, windowsSlashWorkaround=windowsSlashWorkaround):
                 return True
 
         return False

--- a/FTB/Signatures/test_CrashSignature.py
+++ b/FTB/Signatures/test_CrashSignature.py
@@ -727,12 +727,19 @@ class SignatureMatchAssertionSlashes(unittest.TestCase):
         # native paths on windows use backslash
         bs_windows = CrashInfo.fromRawCrashData([], [], cfg_windows, auxCrashData=bs_lines)
 
-        sig = fs_linux.createCrashSignature()
+        # test that signature generated from linux assertion matches both
+        linux_sig = fs_linux.createCrashSignature()
+        assert linux_sig.matches(fs_linux)
+        assert not linux_sig.matches(bs_linux)  # this is invalid and should not match
+        assert linux_sig.matches(fs_windows)
+        assert linux_sig.matches(bs_windows)
 
-        assert sig.matches(fs_linux)
-        assert not sig.matches(bs_linux)  # this is invalid and should not match
-        assert sig.matches(fs_windows)
-        assert sig.matches(bs_windows)
+        # test that signature generated from windows assertion matches both
+        windows_sig = bs_windows.createCrashSignature()
+        assert windows_sig.matches(fs_linux)
+        assert not windows_sig.matches(bs_linux)  # this is invalid and should not match
+        assert windows_sig.matches(fs_windows)
+        assert windows_sig.matches(bs_windows)
 
 
 if __name__ == "__main__":

--- a/FTB/test_AssertionHelper.py
+++ b/FTB/test_AssertionHelper.py
@@ -210,12 +210,16 @@ class AssertionHelperTestWindowsPathSanitizing(unittest.TestCase):
                        r"([a-zA-Z]:)?/.+/Lowering\.cpp(:[0-9]+)+")
 
         assert sanitizedMsg1 == expectedMsg
-
-        # We currently don't support path sanitizing of backward slashes, but if we add support, uncomment this test
-        #assert sanitizedMsg2 == expectedMsg
-
+        assert sanitizedMsg2 == expectedMsg
         _check_regex_matches(err1, sanitizedMsg1)
-        _check_regex_matches(err2, sanitizedMsg2)
+
+        # Backslash support is two-part:
+        # 1. generate unix-style path patterns for windows paths (will not match using regex directly)
+        # 2. modify StringMatch to replace backslash with forward slash for matching (so unix patterns will match
+        #    windows paths)
+        #
+        # That means a test for this can't work at this level
+        #_check_regex_matches(err2, sanitizedMsg2)
 
 
 class AssertionHelperTestAuxiliaryAbortASan(unittest.TestCase):


### PR DESCRIPTION
This approach does the following:

- replace all backslashes in the assertion message with forward slashes
- create assertion pattern as normal (using forward slashes)
- restores backslashes that were not replaced by a pattern
- replaces the path pattern with one that accepts either back/forward-slash

I also removed escaping of `-` since this is not a special character except in a character range (which is already escaped).

Updated tests to match, and altered tests to actually try the resulting pattern instead of just compiling it.

I didn't remember about #198 before-hand. I guess this is an alternate approach to what was discussed there (normalizing input in Collector).