### PR TITLE
[FTB] Use the first MOZ_CRASH entry in a log

### DIFF
--- a/FTB/AssertionHelper.py
+++ b/FTB/AssertionHelper.py
@@ -41,6 +41,9 @@ def getAssertion(output):
     # Use this to ignore the ASan head line in case of an assertion
     haveFatalAssertion = False
 
+    # Used to only accept the initial MOZ_CRASH() line
+    haveMozCrashLine = False
+
     # The self-hosted JS asserts are followed by an additional regular
     # JS assertion which we need to ignore in that case
     haveSelfHostedJSAssert = False
@@ -95,7 +98,9 @@ def getAssertion(output):
             haveFatalAssertion = True
         elif not haveFatalAssertion and "MOZ_CRASH" in line and RE_MOZ_CRASH.search(line):
             # MOZ_CRASH line, but with a message (we should only look at these)
-            lastLine = line
+            if not haveMozCrashLine:
+                lastLine = line
+                haveMozCrashLine = True
         elif "Self-hosted JavaScript assertion info" in line:
             lastLine = line
             haveSelfHostedJSAssert = True

--- a/FTB/test_AssertionHelper.py
+++ b/FTB/test_AssertionHelper.py
@@ -88,7 +88,8 @@ Hit MOZ_CRASH(good message) at /builds/worker/workspace/build/src/gfx/webrender/
 #01: ???[/home/ubuntu/firefox/libxul.so +0x46d7415]
 Hit MOZ_CRASH(Aborting on channel error.) at /builds/worker/workspace/build/src/ipc/glue/MessageChannel.cpp:2658
 #01: ???[/home/ubuntu/firefox/libxul.so +0x10ead39]
-"""
+"""  # noqa
+
 
 def _check_regex_matches(error_lines, sanitized_message):
     if isinstance(sanitized_message, (six.text_type, bytes)):

--- a/FTB/test_AssertionHelper.py
+++ b/FTB/test_AssertionHelper.py
@@ -83,6 +83,12 @@ thread '<unnamed>' panicked at 'assertion failed: `(left == right)`
 
 mozCrashWithPath = "Hit MOZ_CRASH(/builds/worker/workspace/build/src/media/libopus/celt/celt_decoder.c:125 assertion failed: st->start < st->end) at nil:16"  # noqa
 
+multiMozCrash = """
+Hit MOZ_CRASH(good message) at /builds/worker/workspace/build/src/gfx/webrender/src/spatial_node.rs:428
+#01: ???[/home/ubuntu/firefox/libxul.so +0x46d7415]
+Hit MOZ_CRASH(Aborting on channel error.) at /builds/worker/workspace/build/src/ipc/glue/MessageChannel.cpp:2658
+#01: ???[/home/ubuntu/firefox/libxul.so +0x10ead39]
+"""
 
 def _check_regex_matches(error_lines, sanitized_message):
     if isinstance(sanitized_message, (six.text_type, bytes)):
@@ -136,7 +142,6 @@ class AssertionHelperTestMozCrash(unittest.TestCase):
         sanitizedMsg = AssertionHelper.getSanitizedAssertionPattern(AssertionHelper.getAssertion(err))
         expectedMsg = (r"Hit MOZ_CRASH\(named lambda static scopes should have been skipped\) at "
                        r"([a-zA-Z]:)?/.+/ScopeObject\.cpp(:[0-9]+)+")
-
         assert sanitizedMsg == expectedMsg
         _check_regex_matches(err, sanitizedMsg)
 
@@ -148,7 +153,17 @@ class AssertionHelperTestMozCrashWithPath(unittest.TestCase):
         sanitizedMsg = AssertionHelper.getSanitizedAssertionPattern(AssertionHelper.getAssertion(err))
         expectedMsg = (r"Hit MOZ_CRASH\(([a-zA-Z]:)?/.+/celt_decoder\.c(:[0-9]+)+ assertion failed: "
                        r"st->start < st->end\) at nil(:[0-9]+)+")
+        assert sanitizedMsg == expectedMsg
+        _check_regex_matches(err, sanitizedMsg)
 
+
+class AssertionHelperTestMultiMozCrash(unittest.TestCase):
+    def runTest(self):
+        err = multiMozCrash.splitlines()
+
+        sanitizedMsg = AssertionHelper.getSanitizedAssertionPattern(AssertionHelper.getAssertion(err))
+        expectedMsg = (r"Hit MOZ_CRASH\(good message\) at "
+                       r"([a-zA-Z]:)?/.+/spatial_node\.rs(:[0-9]+)+")
         assert sanitizedMsg == expectedMsg
         _check_regex_matches(err, sanitizedMsg)
 


### PR DESCRIPTION
Running Firefox with e10s can lead to multiple MOZ_CRASH entries in stderr. So far I have only seen situations where the initial MOZ_CRASH entry is valid followed by others triggered by the forced shutdown of the remaining processes.