### PR TITLE
[FTB] Fix some flake8 warnings and nits

### DIFF
--- a/FTB/AssertionHelper.py
+++ b/FTB/AssertionHelper.py
@@ -302,9 +302,10 @@ def escapePattern(msg):
 
     escapedStr = msg
 
-    activeChars = ["\\", "[", "]", "{", "}", "(", ")", "*", "+", "?", "^", "$", ".", "|"]
+    activeChars = ("\\", "[", "]", "{", "}", "(", ")", "*", "+", "?", "^", "$", ".", "|")
 
     for activeChar in activeChars:
-        escapedStr = escapedStr.replace(activeChar, "\\" + activeChar)
+        if activeChar in escapedStr:
+            escapedStr = escapedStr.replace(activeChar, "\\" + activeChar)
 
     return escapedStr

--- a/FTB/Signatures/CrashInfo.py
+++ b/FTB/Signatures/CrashInfo.py
@@ -480,7 +480,7 @@ class CrashInfo(object):
                 frame = frame[:idx]
 
         if "lambda" in frame:
-            frame = re.sub("<lambda at .+?:\d+:\d+>", "", frame)
+            frame = re.sub("<lambda at .+?:\\d+:\\d+>", "", frame)
 
         return frame
 
@@ -1044,7 +1044,7 @@ class GDBCrashInfo(CrashInfo):
             return "(" in op and ")" in op
 
         def calculateDerefOpAddress(derefOp):
-            match = re.match("\*?((?:\\-?0x[0-9a-f]+)?)\\(%([a-z0-9]+)\\)", derefOp)
+            match = re.match("\\*?((?:\\-?0x[0-9a-f]+)?)\\(%([a-z0-9]+)\\)", derefOp)
             if match is not None:
                 offset = 0
                 if len(match.group(1)):
@@ -1232,7 +1232,7 @@ class GDBCrashInfo(CrashInfo):
             elif len(parts) == 2:
                 if instruction.startswith("ldr") or instruction.startswith("str"):
                     # Load/Store instruction
-                    match = re.match("^\s*\[(.*)\]$", parts[1])
+                    match = re.match("^\\s*\\[(.*)\\]$", parts[1])
                     if match is not None:
                         (result, reason) = calculateARMDerefOpAddress(match.group(1))
                         if result is None:

--- a/FTB/Signatures/CrashInfo.py
+++ b/FTB/Signatures/CrashInfo.py
@@ -1666,13 +1666,12 @@ class TSanCrashInfo(CrashInfo):
             msg = msg.replace("WARNING: ", "")
 
             if "data race" in msg:
-                if self.tsanIndexZero > 0:
+                if self.tsanIndexZero:
                     msg += " [@ %s]" % self.tsanIndexZero[0]
-
-                if len(self.tsanIndexZero) > 1:
-                    msg += " vs. [@ %s]" % self.tsanIndexZero[1]
+                    if len(self.tsanIndexZero) > 1:
+                        msg += " vs. [@ %s]" % self.tsanIndexZero[1]
             elif "thread leak" in msg:
-                if self.tsanIndexZero > 0:
+                if self.tsanIndexZero:
                     msg += " [@ %s]" % self.tsanIndexZero[0]
             else:
                 raise RuntimeError("Fatal error: TSan trace warning line has unhandled message case: %s" % msg)

--- a/FTB/Signatures/CrashSignature.py
+++ b/FTB/Signatures/CrashSignature.py
@@ -48,7 +48,7 @@ class CrashSignature(object):
         # Get the symptoms objects (mandatory)
         if "symptoms" in obj:
             symptoms = JSONHelper.getArrayChecked(obj, "symptoms", True)
-            if len(symptoms) == 0:
+            if not symptoms:
                 raise RuntimeError("Signature must have at least one symptom.")
 
             for rawSymptomsObj in symptoms:

--- a/FTB/Signatures/tests/test_CrashSignature.py
+++ b/FTB/Signatures/tests/test_CrashSignature.py
@@ -317,7 +317,7 @@ testSignature4 = '''{"symptoms": [
     "type": "testcase",
     "value": {
       "matchType": "pcre",
-      "value": "SIMD\\\.float\\\d+x"
+      "value": "SIMD\\\\.float\\\\d+x"
     }
   }
 ]}


### PR DESCRIPTION
This will remove some flake8 warnings due to incorrect escaping. It also includes some other nits I came across that are easy to fix and may offer some performance benefits (and make things a bit more pythonic). No functional changes are intended.