### PR TITLE
Bump six compatibility library version to 1.12.0

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -41,7 +41,7 @@ pytz>=2018.4
 redis>=2.10.6,<2.11
 requests==2.20.1
 singledispatch>=3.4.0.3,<3.4.1; python_version == '2.7'
-six>=1.11.0,<1.12
+six>=1.12.0,<1.13
 urllib3>=1.22,<2
 vine>=1.1.4,<1.2
 wrapt>=1.10.11,<1.11

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
                        'Topic :: Software Development :: Testing',
                        'Topic :: Security'],
           description='A fuzzing management tools collection',
-          install_requires=['fasteners>=0.14.1', 'numpy>=1.11.2', 'requests>=2.20.1', 'six==1.11.0'],
+          install_requires=['fasteners>=0.14.1', 'numpy>=1.11.2', 'requests>=2.20.1', 'six==1.12.0'],
           keywords='fuzz fuzzing security test testing',
           license='MPL 2.0',
           maintainer='Mozilla Fuzzing Team',


### PR DESCRIPTION
six doesn't seem to get updates that often, but a lot of other Python libraries rely on it, so let's bump here as well.

While I'm at this, I might try and bump some other library dependencies (maybe the linter etc.) but in another PR.