### PR TITLE
[CrashManager] Split post-delete handler into CrashEntry.testcase and TestCase.test.

### DIFF
--- a/server/crashmanager/models.py
+++ b/server/crashmanager/models.py
@@ -364,15 +364,19 @@ class CrashEntry(models.Model):
         return queryset
 
 
-# This post_delete handler ensures that the corresponding testcase
+# These post_delete handlers ensure that the corresponding testcase
 # is also deleted when the CrashEntry is gone. It also explicitely
 # deletes the file on the filesystem which would otherwise remain.
 @receiver(post_delete, sender=CrashEntry)
 def CrashEntry_delete(sender, instance, **kwargs):
     if instance.testcase:
-        if instance.testcase.test:
-            instance.testcase.test.delete(False)
         instance.testcase.delete(False)
+
+
+@receiver(post_delete, sender=TestCase)
+def TestCase_delete(sender, instance, **kwargs):
+    if instance.test:
+        instance.test.delete(False)
 
 
 # post_save handler for celery integration

--- a/server/crashmanager/tests/test_crashes.py
+++ b/server/crashmanager/tests/test_crashes.py
@@ -324,3 +324,28 @@ def test_query_crashes(client, cm):  # pylint: disable=invalid-name
         assert set(crashlist) == exp_crashes  # expected crashes
         # pylint: disable=superfluous-parens
         assert_contains(response, ("Your search matched %d entries in database." % len(exp_crashes)))
+
+
+def test_delete_testcase(cm):
+    """Testcases should be delete when TestCase object is removed"""
+    testcase = cm.create_testcase("test.txt", "hello world")
+    test_file = testcase.test.name
+    storage = testcase.test.storage
+    assert storage.exists(test_file)
+    testcase.delete()
+    if storage.exists(test_file):
+        storage.delete(test_file)
+        raise AssertionError("file should have been deleted with TestCase: %r" % (test_file,))
+
+
+def test_delete_testcase_crash(cm):
+    """Testcases should be delete when CrashInfo object is removed"""
+    testcase = cm.create_testcase("test.txt", "hello world")
+    test_file = testcase.test.name
+    storage = testcase.test.storage
+    assert storage.exists(test_file)
+    crash = cm.create_crash(testcase=testcase)
+    crash.delete()
+    if storage.exists(test_file):
+        storage.delete(test_file)
+        raise AssertionError("file should have been deleted with CrashInfo: %r" % (test_file,))


### PR DESCRIPTION
This ensures that even if a TestCase object is deleted from the shell or
an error handler, the file will be removed too.

Fixes #538