### PR TITLE
Internal task for creating weekly coverage reports automatically.

### DIFF
--- a/server/covmanager/cron.py
+++ b/server/covmanager/cron.py
@@ -1,0 +1,76 @@
+import logging
+import requests
+
+from celeryconf import app
+from dateutil.relativedelta import relativedelta, MO
+from django.conf import settings
+from django.db.models import Q
+
+from crashmanager.models import Client
+from .models import Collection, Repository
+from .tasks import aggregate_coverage_data
+
+logger = logging.getLogger("covmanager")
+
+
+# The `create_current_weekly_report_mc` task and dependencies are part of the
+# internal process at Mozilla to create an aggregated fuzzing coverage report
+# on a weekly basis. For this purpose, a revision is fixed every week and all
+# fuzzing tools perform a coverage run on the that revision (during the week).
+# At the end of the week, the code below fetches all reports belonging to that
+# revision (which is published as an URL) and aggregates them into a combined
+# weekly report. You can use the same logic if you have a large project with
+# multiple testing tools and would like to automate the process of generating
+# a summarized report for your testing efforts.
+
+
+def create_weekly_report_mc(revision):
+    # Some of our builds (e.g. JS shell) use the HG short revision format
+    # to submit their coverage while the server provides the full revision.
+    short_revision = revision[:12]
+
+    repository = Repository.objects.get(name="mozilla-central")
+    client = Client.objects.get_or_create(name="Server")
+
+    collections = Collection.objects.filter(
+        Q(revision=revision) | Q(revision=short_revision)).filter(repository=repository)
+
+    last_monday = collections.first().created + relativedelta(weekday=MO(-1))
+
+    mergedCollection = Collection()
+    mergedCollection.description = "Weekly Report (Week of %s, %s reports)" % (
+        last_monday.strftime("%-m/%-d"), collections.count())
+    mergedCollection.repository = repository
+    mergedCollection.revision = revision
+    mergedCollection.branch = "master"
+    mergedCollection.client = client
+    mergedCollection.coverage = None
+    mergedCollection.save()
+
+    # New set of tools is the combination of all tools involved
+    tools = []
+    for collection in collections:
+        tools.extend(collection.tools.all())
+    mergedCollection.tools.add(*tools)
+
+    ids = list(collections.values_list('id', flat=True))
+
+    aggregate_coverage_data.delay(mergedCollection.pk, ids)
+
+
+@app.task
+def create_current_weekly_report_mc():
+    COVERAGE_REVISION_URL = getattr(settings, 'COVERAGE_REVISION_URL', None)
+
+    if not COVERAGE_REVISION_URL:
+        logger.error("Missing configuration for COVERAGE_REVISION_URL.")
+        return
+
+    response = requests.get(COVERAGE_REVISION_URL)
+    if not response.ok:
+        logger.error("Failed fetching coverage revision. Got status %s with response: %s",
+                     response.status_code, response.text)
+        return
+
+    revision = response.text.rstrip()
+    return create_weekly_report_mc(revision)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,6 +11,7 @@ certifi>=2018.4.16
 chardet>=3.0.4,<3.1
 configparser>=3.5.0,<3.6; python_version == '2.7'
 coverage==4.5.2
+dateutil>=2.8,<3
 Django>=1.11.16,<1.12
 django-chartjs==1.3
 djangorestframework>=3.8.2,<3.9


### PR DESCRIPTION
This is the initial draft for #548. I did not add any `server.py` configuration because it is unlikely that a user would want to enable this as-is. Nevertheless, it is easiest for us to have this code in the main repo (and it may serve as a template for others that want to do something similar).

I've factored out `create_weekly_report_mc` because I'd like to be able to call it for past reports as well, independent of the current week (and in rare occasions we might want to do this again, e.g. when reports arrived later than anticipated, runs had to be repeated etc.).

This code currently cannot detect if runs are missing because there is no list of expected runs available. It also does not check for "broken" runs (whatever the definition of broken might be here). So this code is overall not too resistant to missing/invalid weekly reports but I don't see an easily solution for this in the near future.