### PR TITLE
Clicking on "Mark this bucket as a permanent bucket" should select its corresponding checkbox

### DIFF
--- a/server/crashmanager/templates/signatures/edit.html
+++ b/server/crashmanager/templates/signatures/edit.html
@@ -28,7 +28,7 @@
 
             <div class="field">
                 <input type="checkbox" id="id_permanent" name="permanent" value="unassigned" {% if bucket.permanent %}checked{% endif %}/>
-                <label for="id_frequent">Mark this bucket as a permanent bucket</label>
+                <label for="id_permanent">Mark this bucket as a permanent bucket</label>
             </div>
 
             <div class="field">


### PR DESCRIPTION
Clicking on "Mark this bucket as a permanent bucket" currently selects the "frequent bucket" checkbox. This PR fixes it.