### PR TITLE
Fix #562 - [CrashManager] LSan parsing fails with Index mismatch when multiple stacks are passed in

### DIFF
--- a/FTB/Signatures/CrashInfo.py
+++ b/FTB/Signatures/CrashInfo.py
@@ -682,12 +682,20 @@ class LSanCrashInfo(CrashInfo):
         lsanOutput = crashData if crashData else stderr
         lsanErrorPattern = "ERROR: LeakSanitizer:"
         lsanPatternSeen = False
+        lsanStackStartPattern = "Direct leak of "
+        lsanStackStartPatternCount = 0
 
         expectedIndex = 0
         for traceLine in lsanOutput:
             if not lsanErrorPattern:
                 if lsanErrorPattern in traceLine:
                     lsanPatternSeen = True
+                continue
+
+            if lsanStackStartPattern in traceLine:
+                if lsanStackStartPatternCount > 0:
+                    break
+                lsanStackStartPatternCount += 1
                 continue
 
             parts = traceLine.strip().split()

--- a/FTB/Signatures/CrashInfo.py
+++ b/FTB/Signatures/CrashInfo.py
@@ -682,8 +682,8 @@ class LSanCrashInfo(CrashInfo):
         lsanOutput = crashData if crashData else stderr
         lsanErrorPattern = "ERROR: LeakSanitizer:"
         lsanPatternSeen = False
-        lsanStackStartPattern = "Direct leak of "
-        lsanStackStartPatternCount = 0
+        lsanStackPattern = "direct leak of "
+        lsanStackPatternCount = 0
 
         expectedIndex = 0
         for traceLine in lsanOutput:
@@ -692,10 +692,10 @@ class LSanCrashInfo(CrashInfo):
                     lsanPatternSeen = True
                 continue
 
-            if lsanStackStartPattern in traceLine:
-                if lsanStackStartPatternCount > 0:
+            if lsanStackPattern in traceLine.lower():
+                if lsanStackPatternCount > 0:
                     break
-                lsanStackStartPatternCount += 1
+                lsanStackPatternCount += 1
                 continue
 
             parts = traceLine.strip().split()


### PR DESCRIPTION
This seems to fix it for me. If the general approach works, I'll add tests in a follow-up commit.

Sample failing testcase: (stripped to just 2 stacks with the second stack snipped)

```
LLVMSymbolizer: error reading file: No such file or directory

 =================================================================
 ==18890==ERROR: LeakSanitizer: detected memory leaks

 Direct leak of 32 byte(s) in 1 object(s) allocated from:
     #0 0xaaaabc3c3e03 in malloc (/home/ubuntu/shell-cache/js-dbg-64-dm-asan-linux-aarch64-8537d24d8aa8/js-dbg-64-dm-asan-linux-aarch64-8537d24d8aa8+0xb39e03)
     #1 0xaaaabc87a697 in js_arena_malloc(unsigned long, unsigned long) /home/ubuntu/shell-cache/js-dbg-64-dm-asan-linux-aarch64-8537d24d8aa8/objdir-js/dist/include/js/Utility.h:368:10
     #2 0xaaaabc87a697 in char* js_pod_arena_malloc<char>(unsigned long, unsigned long) /home/ubuntu/shell-cache/js-dbg-64-dm-asan-linux-aarch64-8537d24d8aa8/objdir-js/dist/include/js/Utility.h:573
     #3 0xaaaabc87a697 in char* js::AllocPolicyBase::maybe_pod_arena_malloc<char>(unsigned long, unsigned long) /home/ubuntu/shell-cache/js-dbg-64-dm-asan-linux-aarch64-8537d24d8aa8/objdir-js/dist/include/js/AllocPolicy.h:31
     #4 0xaaaabc87a697 in char* js::AllocPolicyBase::maybe_pod_malloc<char>(unsigned long) /home/ubuntu/shell-cache/js-dbg-64-dm-asan-linux-aarch64-8537d24d8aa8/objdir-js/dist/include/js/AllocPolicy.h:58
     #5 0xaaaabc87a697 in mozilla::SprintfState<js::SystemAllocPolicy>::append(char const*, unsigned long) /home/ubuntu/shell-cache/js-dbg-6-dm-asan-linux-aarch64-8537d24d8aa8/objdir-js/dist/include/mozilla/Printf.h:176
     #6 0xaaaabc4f21ab in mozilla::PrintfTarget::emit(char const*, unsigned long) /home/ubuntu/shell-cache/js-dbg-64-dm-asan-linux-aarch64-8537d24d8aa8/objdir-js/dist/include/mozilla/Printf.h:108:12
     #7 0xaaaabc4f21ab in mozilla::PrintfTarget::vprint(char const*, std::__va_list) /home/ubuntu/trees/mozilla-central/mozglue/misc/Printf.cpp:633
     #8 0xaaaabc86e68f in mozilla::SprintfState<js::SystemAllocPolicy>::vprint(char const*, std::__va_list) /home/ubuntu/shell-cache/js-dbg-64-dm-asan-linux-aarch64-8537d24d8aa8/objdir-js/dist/include/mozilla/Printf.h:157:35
     #9 0xaaaabc86e68f in mozilla::UniquePtr<char, mozilla::detail::AllocPolicyBasedFreePolicy<js::SystemAllocPolicy> > mozilla::Vsmprintf<js::SystemAllocPolicy>(char const*, std::__va_list) /home/ubuntu/shell-cache/js-dbg-64-dm-asan-linux-aarch64-8537d24d8aa8/objdir-js/dist/include/mozilla/Printf.h:249
     #10 0xaaaabc86e68f in JS_vsmprintf(char const*, std::__va_list) /home/ubuntu/trees/mozilla-central/js/src/util/Printf.cpp:44
     #11 0xaaaabee9e2b7 in GenPrintf(js::wasm::DebugChannel, js::jit::MacroAssembler&, char const*, ...) /home/ubuntu/trees/mozilla-central/js/src/wasm/WasmStubs.cpp:73:21
     #12 0xaaaabeeb69bb in js::wasm::GenerateStubs(js::wasm::ModuleEnvironment const&, mozilla::Vector<js::wasm::FuncImport, 0ul, js::SystemAllocPolicy> const&, mozilla::Vector<js::wasm::FuncExport, 0ul, js::SystemAllocPolicy> const&, js::wasm::CompiledCode*) /home/ubuntu/trees/mozilla-central/js/src/wasm/WasmStubs.cpp:1533:7
     #13 0xaaaabed393db in js::wasm::ModuleGenerator::finishCodeTier() /home/ubuntu/trees/mozilla-central/js/src/wasm/WasmGenerator.cpp:1023:8
     #14 0xaaaabed3c33f in js::wasm::ModuleGenerator::finishModule(js::wasm::ShareableBytes const&, JS::OptimizedEncodingListener*) /home/ubuntu/trees/mozilla-central/js/src/wasm/WasmGenerator.cpp:1121:29
     #15 0xaaaabebbe6c3 in js::wasm::CompileBuffer(js::wasm::CompileArgs const&, js::wasm::ShareableBytes const&, mozilla::UniquePtr<char [], JS::FreePolicy>*, mozilla::Vector<mozilla::UniquePtr<char [], JS::FreePolicy>, 0ul, js::SystemAllocPolicy>*, JS::OptimizedEncodingListener*) /home/ubuntu/trees/mozilla-central/js/src/wasm/WasmCompile.cpp:588:13
     #16 0xaaaabeda7677 in js::WasmModuleObject::construct(JSContext*, unsigned int, JS::Value*) /home/ubuntu/trees/mozilla-central/js/src/wasm/WasmJS.cpp:1136:7
     #17 0xaaaabc5f193f in CallJSNative(JSContext*, bool (*)(JSContext*, unsigned int, JS::Value*), JS::CallArgs const&) /home/ubuntu/trees/mozilla-central/js/src/vm/Interpreter.cpp:448:13
     #18 0xaaaabc5ff6a3 in CallJSNativeConstructor(JSContext*, bool (*)(JSContext*, unsigned int, JS::Value*), JS::CallArgs const&) /home/ubuntu/trees/mozilla-central/js/src/vm/Interpreter.cpp:464:8
     #19 0xaaaabc5c904b in InternalConstruct(JSContext*, js::AnyConstructArgs const&) /home/ubuntu/trees/mozilla-central/js/src/vm/Interpreter.cpp:638:14
     #20 0xaaaabdfa54ab in js::jit::DoCallFallback(JSContext*, js::jit::BaselineFrame*, js::jit::ICCall_Fallback*, unsigned int, JS::Value*, JS::MutableHandle<JS::Value>) /home/ubuntu/trees/mozilla-central/js/src/jit/BaselineIC.cpp:3191:10
     #21 0x25e86516ee7f  (<unknown module>)
     #22 0xfffffaba804f  ([stack]+0x5104f)

 Direct leak of 32 byte(s) in 1 object(s) allocated from:
     #0 0xaaaabc3c3e03 in malloc (/home/ubuntu/shell-cache/js-dbg-64-dm-asan-linux-aarch64-8537d24d8aa8/js-dbg-64-dm-asan-linux-aarch64-8537d24d8aa8+0xb39e03)
     #1 0xaaaabc87a697 in js_arena_malloc(unsigned long, unsigned long) /home/ubuntu/shell-cache/js-dbg-64-dm-asan-linux-aarch64-8537d24d8aa8/objdir-js/dist/include/js/Utility.h:368:10

 SUMMARY: AddressSanitizer: 384 byte(s) leaked in 12 allocation(s).
```