### PR TITLE
Add X-BUGZILLA-API-KEY support

### DIFF
--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -284,6 +284,9 @@ GCE_AUTH_CACHE = "/tmp/.google_libcloud_auth.fuzzmanager-cluster"
 
 # Crashmanager configuration
 #
+# FuzzManager supports username/password authentication as well as API keys
+# for authenticating to a Bugzilla instance. Omitting the username will cause
+# the password to be used as an API key instead.
 #BUGZILLA_USERNAME = "example@example.com"
 #BUGZILLA_PASSWORD = "secret"
 #CLEANUP_CRASHES_AFTER_DAYS = 14


### PR DESCRIPTION
This PR adds support for `X-BUGZILLA-API-KEY` which allows transmitting an API key in the request header instead of embedding it in the URL parameters. The implementation still supports traditional username/password authentication in case anyone is using that. This also clarifies `settings.py` documentation about the dual use of the `BUGZILLA_PASSWORD` field (which is used as API key if there is no `BUGZILLA_USERNAME` specified). This behavior was originally implemented because the bug filing UI has no extra field for an API key.