### PR TITLE
Output error message for provider failures 

### DIFF
--- a/server/crashmanager/Bugtracker/BugzillaProvider.py
+++ b/server/crashmanager/Bugtracker/BugzillaProvider.py
@@ -308,7 +308,13 @@ class BugzillaProvider(Provider):
         bz = BugzillaREST(self.hostname, username, password, api_key)
         ret = bz.createBug(**args)
         if ret.status_code != 200:
-            content = json.loads(ret.content)
+            try:
+                content = json.loads(ret.content)
+                if 'message' not in content:
+                    raise ValueError
+            except ValueError:
+                raise BugzillaProviderException('Invalid JSON response')
+
             raise BugzillaProviderException(content['message'])
 
         body = ret.json()

--- a/server/crashmanager/Bugtracker/BugzillaREST.py
+++ b/server/crashmanager/Bugtracker/BugzillaREST.py
@@ -133,8 +133,7 @@ class BugzillaREST():
         if self.login():
             createUrl = "%s?token=%s" % (createUrl, self.authToken)
 
-        response = requests.post(createUrl, bug, headers=self.request_headers)
-        return response.json()
+        return requests.post(createUrl, bug, headers=self.request_headers)
 
     def createComment(self, id, comment, is_private=False):
         if is_private:

--- a/server/crashmanager/Bugtracker/Provider.py
+++ b/server/crashmanager/Bugtracker/Provider.py
@@ -24,6 +24,7 @@ class ProviderException(Exception):
     ''' Generic Exception for Provider related errors '''
     pass
 
+
 @six.add_metaclass(ABCMeta)
 class Provider():
     '''

--- a/server/crashmanager/Bugtracker/Provider.py
+++ b/server/crashmanager/Bugtracker/Provider.py
@@ -20,6 +20,10 @@ from abc import ABCMeta, abstractmethod
 import six
 
 
+class ProviderException(Exception):
+    ''' Generic Exception for Provider related errors '''
+    pass
+
 @six.add_metaclass(ABCMeta)
 class Provider():
     '''

--- a/server/crashmanager/views.py
+++ b/server/crashmanager/views.py
@@ -24,6 +24,7 @@ from FTB.Signatures.CrashInfo import CrashInfo
 from .models import CrashEntry, Bucket, BucketWatch, BugProvider, Bug, Tool, User
 from .serializers import InvalidArgumentException, BucketSerializer, CrashEntrySerializer
 from server.auth import CheckAppPermission
+from Bugtracker.Provider import ProviderException
 
 from django.conf import settings as django_settings
 
@@ -959,7 +960,10 @@ def createExternalBug(request, crashid):
 
         # Let the provider handle the POST request, which will file the bug
         # and return us the external bug ID
-        extBugId = provider.getInstance().handlePOSTCreate(request, entry)
+        try:
+            extBugId = provider.getInstance().handlePOSTCreate(request, entry)
+        except ProviderException as e:
+            return renderError(request, e.message)
 
         # Now create a bug in our database with that ID and assign it to the bucket
         extBug = Bug(externalId=extBugId, externalType=provider)


### PR DESCRIPTION
Currently, provider error messages are obscured by django request exceptions.  This PR adds a ProviderExceptions class and returns error messages containing the provider response.  