### PR TITLE
Use tox for running pytest.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,7 @@
 [run]
 omit =
     setup.py
+    dist/*
     */tests/*
+    .tox/*
+    .eggs/*

--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,10 @@
 # JetBrains
 .idea/
 
+coverage/
 /server/db.sqlite3
 /server/settings.secret
 /server/tests/
-/server/coverage/
 /server/logs
 /test/
 /signatures/
@@ -31,3 +31,5 @@
 # Linting via pytest
 /.pytest_cache/
 
+/.eggs/
+/.tox/

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,0 +1,85 @@
+version: 1
+policy:
+  pullRequests: collaborators
+tasks:
+  $let:
+    user: ${event.sender.login}
+
+    head_rev:
+      $if: 'tasks_for == "github-pull-request"'
+      then: ${event.pull_request.head.sha}
+      else:
+        $if: 'tasks_for == "github-push"'
+        then: ${event.after}
+        else: ${event.release.tag_name}
+
+    http_repo:
+      $if: 'tasks_for == "github-pull-request"'
+      then: ${event.pull_request.head.repo.html_url}
+      else: ${event.repository.html_url}
+
+    ssh_repo:
+      $if: 'tasks_for == "github-pull-request"'
+      then: ${event.pull_request.head.repo.ssh_url}
+      else: ${event.repository.ssh_url}
+
+    secret_url:
+      http://taskcluster/secrets/v1/secret/project/fuzzing/fuzzmanager-codecov
+
+  in:
+    $if: 'tasks_for in ["github-pull-request", "github-push"]'
+    then:
+      $map:
+        - {pyver: 2.7, toxenv: 'py27', name: 'tests python 2.7'}
+        - {pyver: 3.5, toxenv: 'py35', name: 'tests python 3.5'}
+        - {pyver: 3.6, toxenv: 'py36', name: 'tests python 3.6'}
+        - {pyver: 3.7, toxenv: 'py37', name: 'tests python 3.7'}
+        - {pyver: 3.8, toxenv: 'py38', name: 'tests python 3.8'}
+        - {pyver: 3.5, toxenv: 'py35-2.0', name: 'tests python 3.5 django 2.x'}
+        - {pyver: 3.6, toxenv: 'py36-2.0', name: 'tests python 3.6 django 2.x'}
+        - {pyver: 3.7, toxenv: 'py37-2.0', name: 'tests python 3.7 django 2.x'}
+        - {pyver: 3.8, toxenv: 'py38-2.0', name: 'tests python 3.8 django 2.x'}
+        - {pyver: 3.6, toxenv: 'py36-3.0', name: 'tests python 3.6 django 3.x'}
+        - {pyver: 3.7, toxenv: 'py37-3.0', name: 'tests python 3.7 django 3.x'}
+        - {pyver: 3.8, toxenv: 'py38-3.0', name: 'tests python 3.8 django 3.x'}
+        - {pyver: 2.7, toxenv: 'py27-next', name: 'tests python 2.7 bleeding edge'}
+        - {pyver: 3.5, toxenv: 'py35-next', name: 'tests python 3.5 bleeding edge'}
+        - {pyver: 3.6, toxenv: 'py36-next', name: 'tests python 3.6 bleeding edge'}
+        - {pyver: 3.7, toxenv: 'py37-next', name: 'tests python 3.7 bleeding edge'}
+        - {pyver: 3.8, toxenv: 'py38-next', name: 'tests python 3.8 bleeding edge'}
+      each(build):
+        provisionerId: proj-fuzzing
+        workerType: ci
+        created: {$fromNow: ''}
+        deadline: {$fromNow: '1 hour'}
+        scopes: [secrets:get:project/fuzzing/fuzzmanager-codecov]
+        payload:
+          maxRunTime: 3600
+          image: python:${build.pyver}-slim
+          features:
+            taskclusterProxy: true
+          command:
+            - /bin/bash
+            - '--login'
+            - '-x'
+            - '-c'
+            - >-
+              echo "[global]\ndisable-pip-version-check = true\nno-cache-dir = false\n" > /etc/pip.conf &&
+              apt-get update -qq &&
+              apt-get install -y -qq --no-install-recommends --no-install-suggests build-essential curl git openssh-client &&
+              cd ~ &&
+              mkdir .ssh &&
+              ssh-keyscan github.com > .ssh/known_hosts &&
+              export CODECOV_TOKEN="$(curl -L ${secret_url} | python -c 'import json, sys; a = json.load(sys.stdin); sys.stdout.write(a["secret"]["token"])')" &&
+              git clone --quiet $http_repo} repo &&
+              cd repo &&
+              git -c advice.detachedHead=false checkout ${head_rev} &&
+              pip -q install tox &&
+              export TOXENV=${build.toxenv} &&
+              tox &&
+              tox -e coverage
+        metadata:
+          name: FuzzManager ${build.name}
+          description: FuzzManager ${build.name}
+          owner: '${event.sender.login}@users.noreply.github.com'
+          source: ${http_repo}/raw/${head_rev}/.taskcluster.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,68 @@
-dist: xenial
+dist: bionic
 sudo: false
 language: python
-python:
-    - 2.7
-    - 3.4
-    - 3.5
-    - 3.6
-    - 3.7
 env:
     global:
         - BOTO_CONFIG=/dev/null
-    matrix:
-        - DJANGO=2.0
-        - DJANGO=1.11
 matrix:
-    exclude:
+    include:
         - python: 2.7
-          env: DJANGO=2.0
+          env: TOXENV=py27
+        - python: 2.7
+          env: TOXENV=py27-next
+        - python: 3.5
+          env: TOXENV=py35
+        - python: 3.5
+          env: TOXENV=py35-2.0
+        - python: 3.5
+          env: TOXENV=py35-next
+        - python: 3.6
+          env: TOXENV=py36
+        - python: 3.6
+          env: TOXENV=py36-2.0
+        - python: 3.6
+          env: TOXENV=py36-3.0
+        - python: 3.6
+          env: TOXENV=py36-next
+        - python: 3.7
+          env: TOXENV=py37
+        - python: 3.7
+          env: TOXENV=py37-2.0
+        - python: 3.7
+          env: TOXENV=py37-3.0
+        - python: 3.7
+          env: TOXENV=py37-next
+        - python: 3.8
+          env: TOXENV=py38
+        - python: 3.8
+          env: TOXENV=py38-2.0
+        - python: 3.8
+          env: TOXENV=py38-3.0
+        - python: 3.8
+          env: TOXENV=py38-next
     allow_failures:
-        - env: DJANGO=2.0
+        - env: TOXENV=py35-2.0
+        - env: TOXENV=py36-2.0
+        - env: TOXENV=py37-2.0
+        - env: TOXENV=py38-2.0
+        - env: TOXENV=py36-3.0
+        - env: TOXENV=py37-3.0
+        - env: TOXENV=py38-3.0
+        - env: TOXENV=py27-next
+        - env: TOXENV=py35-next
+        - env: TOXENV=py36-next
+        - env: TOXENV=py37-next
+        - env: TOXENV=py38-next
 services:
     - redis-server
-before_install:
+-before_install:
     - pip install --upgrade setuptools pip
-    - pip install --upgrade virtualenv
 install:
-    - pip --version
-    - virtualenv --version
-    - git --version
-before_script:
-    - pip install -r server/requirements.txt
-    - if [ "$DJANGO" = "2.0" ]; then pip install "Django>2.0"; fi
-    - pip install --upgrade codecov
+    - pip install --upgrade tox
 script:
-    - python -m pytest
+    - tox
 after_success:
-    - codecov -X gcov
+    - tox -e codecov
 deploy:
     provider: pypi
     distributions: sdist bdist_wheel

--- a/server/requirements2.0.txt
+++ b/server/requirements2.0.txt
@@ -11,7 +11,7 @@ certifi>=2018.4.16
 chardet>=3.0.4,<3.1
 configparser>=3.5.0,<3.6; python_version == '2.7'
 coverage==4.5.2
-Django>=1.11.20,<1.12
+Django>=2.2,<3
 django-chartjs==1.3
 djangorestframework>=3.9.4,<3.10
 enum34>=1.1.6,<1.2; python_version == '2.7'

--- a/server/requirements3.0.txt
+++ b/server/requirements3.0.txt
@@ -11,7 +11,7 @@ certifi>=2018.4.16
 chardet>=3.0.4,<3.1
 configparser>=3.5.0,<3.6; python_version == '2.7'
 coverage==4.5.2
-Django>=1.11.20,<1.12
+Django>=3.0,<3.1
 django-chartjs==1.3
 djangorestframework>=3.9.4,<3.10
 enum34>=1.1.6,<1.2; python_version == '2.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,62 @@
 [bdist_wheel]
-universal=1
+universal = 1
+
+[metadata]
+name = FuzzManager
+version = 0.3.1
+author = Christian Holler
+description = A fuzzing management tools collection
+license = MPL 2.0
+url = https://github.com/MozillaSecurity/FuzzManager
+maintainer = Mozilla Fuzzing Team
+maintainer_email = fuzzing@mozilla.com
+classifiers =
+    Intended Audience :: Developers
+    License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Software Development :: Testing
+    Topic :: Security
+keywords = fuzz fuzzing security test testing
+
+[options]
+install_requires =
+    fasteners>=0.14.1
+    numpy>=1.11.2,<1.17
+    requests>=2.20.1
+    six>=1.12.0
+packages =
+    Collector
+    CovReporter
+    EC2Reporter
+    FTB
+    FTB.Running
+    FTB.Signatures
+    Reporter
+
+[options.extras_require]
+dev =
+    tox>=3.2
+test =
+# these are broad requirements. tox uses frozen requirements in server/requirements.txt
+    boto3
+    celery
+    django
+    django-chartjs
+    djangorestframework
+    laniakea
+    pytest
+    pytest-cov
+    pytest-django
+    pytest-flake8
+    pytest-mock
+    pytest-pythonpath
+    pyyaml
+    redis

--- a/setup.py
+++ b/setup.py
@@ -2,26 +2,7 @@
 from setuptools import setup
 
 if __name__ == '__main__':
-    setup(author='Christian Holler',
-          classifiers=['Intended Audience :: Developers',
-                       'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
-                       'Operating System :: OS Independent',
-                       'Programming Language :: Python',
-                       'Programming Language :: Python :: 2',
-                       'Programming Language :: Python :: 2.7',
-                       'Programming Language :: Python :: 3',
-                       'Programming Language :: Python :: 3.4',
-                       'Programming Language :: Python :: 3.5',
-                       'Programming Language :: Python :: 3.6',
-                       'Topic :: Software Development :: Testing',
-                       'Topic :: Security'],
-          description='A fuzzing management tools collection',
-          install_requires=['fasteners>=0.14.1', 'numpy>=1.11.2,<1.17', 'requests>=2.20.1', 'six>=1.12.0'],
-          keywords='fuzz fuzzing security test testing',
-          license='MPL 2.0',
-          maintainer='Mozilla Fuzzing Team',
-          maintainer_email='fuzzing@mozilla.com',
-          name='FuzzManager',
-          packages=['Collector', 'CovReporter', 'EC2Reporter', 'FTB', 'FTB.Running', 'FTB.Signatures', 'Reporter'],
-          url='https://github.com/MozillaSecurity/FuzzManager',
-          version='0.3.1')
+    setup(
+        use_scm_version=True,
+        setup_requires=['setuptools_scm'],
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,86 @@
+[tox]
+envlist = py{27,35,36,37,38}
+minversion = 3.2
+tox_pip_extensions_ext_venv_update = true
+skip_missing_interpreters = true
+
+[testenv]
+extras = test
+usedevelop = true
+commands = pytest --flake8 -v --cov="{toxinidir}" --cov-report term-missing --basetemp="{envtmpdir}" {posargs}
+passenv =
+    TOXENV
+    CI
+    TRAVIS
+    TRAVIS_*
+    CODECOV_*
+deps =
+    -r{toxinidir}/server/requirements.txt
+
+[testenv:codecov]
+deps =
+    codecov
+commands =
+    codecov -X gcov
+
+# test with frozen requirements for Django 2.x
+[testenv:py35-2.0]
+basepython = python3.5
+deps =
+    -r{toxinidir}/server/requirements2.0.txt
+
+[testenv:py36-2.0]
+basepython = python3.6
+deps =
+    -r{toxinidir}/server/requirements2.0.txt
+
+[testenv:py37-2.0]
+basepython = python3.7
+deps =
+    -r{toxinidir}/server/requirements2.0.txt
+
+[testenv:py38-2.0]
+basepython = python3.8
+deps =
+    -r{toxinidir}/server/requirements2.0.txt
+
+# test with frozen requirements for Django 3.x
+[testenv:py36-3.0]
+basepython = python3.6
+deps =
+    -r{toxinidir}/server/requirements3.0.txt
+
+[testenv:py37-3.0]
+basepython = python3.7
+deps =
+    -r{toxinidir}/server/requirements3.0.txt
+
+[testenv:py38-3.0]
+basepython = python3.8
+deps =
+    -r{toxinidir}/server/requirements3.0.txt
+
+# test with unfrozen requirements (latest for all deps)
+[testenv:py27-next]
+basepython = python2.7
+deps =
+
+[testenv:py35-next]
+basepython = python3.5
+deps =
+
+[testenv:py36-next]
+basepython = python3.6
+deps =
+
+[testenv:py37-next]
+basepython = python3.7
+deps =
+
+[testenv:py38-next]
+basepython = python3.8
+deps =
+
 [flake8]
 # This ignore section is for running flake8 standalone vs through pytest
 ignore =


### PR DESCRIPTION
Tox automates creating a virtual environment for running tests in isolation.

This should be a no-op for local use, if you want to continue using `pytest` to invoke. But you will also be able to use `tox` to test against all available interpreters, or `tox -e py27` to use specific ones. Pytest options can be added after `--`, eg. `tox -- -k collector` to run only collector tests.