### PR TITLE
Remove numpy.

### DIFF
--- a/FTB/Signatures/tests/test_CrashInfo.py
+++ b/FTB/Signatures/tests/test_CrashInfo.py
@@ -12,13 +12,13 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @contact:    choller@mozilla.com
 '''
-from numpy import int64, uint64, int32, uint32
 import os
 
 from FTB.ProgramConfiguration import ProgramConfiguration
 from FTB.Signatures import RegisterHelper
 from FTB.Signatures.CrashInfo import ASanCrashInfo, GDBCrashInfo, CrashInfo, \
-    NoCrashInfo, MinidumpCrashInfo, AppleCrashInfo, CDBCrashInfo, RustCrashInfo
+    NoCrashInfo, MinidumpCrashInfo, AppleCrashInfo, CDBCrashInfo, RustCrashInfo, \
+    int32
 from FTB.Signatures.CrashSignature import CrashSignature
 
 CWD = os.path.dirname(os.path.realpath(__file__))
@@ -1020,10 +1020,8 @@ def test_GDBParserTestCrashAddressSimple():
     assert GDBCrashInfo.calculateCrashAddress("mov    %rax,0x10(%rbx)", registerMap64) == 0xF
     assert GDBCrashInfo.calculateCrashAddress("mov    %eax,0x10(%ebx)", registerMap32) == 0xF
 
-    assert (GDBCrashInfo.calculateCrashAddress("mov    %rbx,-0x10(%rax)", registerMap64) ==
-            int64(uint64(0xfffffffffffffff0)))
-    assert (GDBCrashInfo.calculateCrashAddress("mov    %ebx,-0x10(%eax)", registerMap32) ==
-            int32(uint32(0xfffffff0)))
+    assert GDBCrashInfo.calculateCrashAddress("mov    %rbx,-0x10(%rax)", registerMap64) == -16
+    assert GDBCrashInfo.calculateCrashAddress("mov    %ebx,-0x10(%eax)", registerMap32) == -16
 
     # Scalar test
     assert GDBCrashInfo.calculateCrashAddress("movl   $0x7b,0x0", registerMap32) == 0x0
@@ -1032,11 +1030,11 @@ def test_GDBParserTestCrashAddressSimple():
     # Note: The crash address here can also be 0xf7600000 because the double quadword
     # move can fail on the second 8 bytes if the source address is not 16-byte aligned
     assert (GDBCrashInfo.calculateCrashAddress("movdqu 0x40(%ecx),%xmm4", registerMap32) ==
-            int32(uint32(0xf75ffff8)))
+            int32(0xf75ffff8))
 
     # Again, this is an unaligned access and the crash can be at 0x7ffff6700000 or 0x7ffff6700000 - 4
     assert (GDBCrashInfo.calculateCrashAddress("mov    -0x4(%rdi,%rsi,2),%eax", registerMap64) ==
-            int64(uint64(0x7ffff66ffffe)))
+            0x7ffff66ffffe)
 
 
 def test_GDBParserTestRegression1():

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -28,7 +28,6 @@ mccabe>=0.6.1,<0.7
 mock==2.0.0; python_version == '2.7'
 monotonic==1.5
 more-itertools>=4.2.0,<4.4
-numpy>=1.14.3,<1.17
 pluggy>=0.7.0,<0.8
 py>=1.5.3
 pycodestyle>=2.5,<2.6

--- a/server/requirements3.0.txt
+++ b/server/requirements3.0.txt
@@ -28,7 +28,6 @@ mccabe>=0.6.1,<0.7
 mock==2.0.0; python_version == '2.7'
 monotonic==1.5
 more-itertools>=4.2.0,<4.4
-numpy>=1.14.3,<1.17
 pluggy>=0.7.0,<0.8
 py>=1.5.3
 pycodestyle>=2.5,<2.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ keywords = fuzz fuzzing security test testing
 [options]
 install_requires =
     fasteners>=0.14.1
-    numpy>=1.11.2,<1.17
     requests>=2.20.1
     six>=1.12.0
 packages =


### PR DESCRIPTION
numpy is a heavyweight module to install just for the native type support which is easily emulated in Python.

I added doctests just to show that the operations are correct. (run with `python3 -m doctest FTB/Signatures/CrashInfo.py`, python2 will fail only because of `L` suffix on 64-bit results).

Casting everything to `uint32`/`uint64` before addition/multiplication means all math is in two's complement representation, where the final "cast" to `int32`/`int64` truncates the result to the desired range.

This could be slightly slower than using numpy, but I don't think this is in the critical path for signature matching.