### PR TITLE
Standardize how signatures are displayed and used.

### DIFF
--- a/FTB/Signatures/CrashInfo.py
+++ b/FTB/Signatures/CrashInfo.py
@@ -523,7 +523,7 @@ class CrashInfo(object):
 
         sigObj = {"symptoms": symptomArr}
 
-        return CrashSignature(json.dumps(sigObj, indent=2))
+        return CrashSignature(json.dumps(sigObj, indent=2, sort_keys=True))
 
     @staticmethod
     def sanitizeStackFrame(frame):

--- a/FTB/Signatures/CrashSignature.py
+++ b/FTB/Signatures/CrashSignature.py
@@ -14,7 +14,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 @contact:    choller@mozilla.com
 '''
 
-from collections import OrderedDict
 import difflib
 import json
 

--- a/FTB/Signatures/CrashSignature.py
+++ b/FTB/Signatures/CrashSignature.py
@@ -41,7 +41,7 @@ class CrashSignature(object):
         self.symptoms = []
 
         try:
-            obj = json.loads(rawSignature, object_pairs_hook=OrderedDict)
+            obj = json.loads(rawSignature)
         except ValueError as e:
             raise RuntimeError("Invalid JSON: %s" % e)
 
@@ -198,7 +198,7 @@ class CrashSignature(object):
         if not sigSymptoms:
             return None
 
-        return CrashSignature(json.dumps(sigObj, indent=2))
+        return CrashSignature(json.dumps(sigObj, indent=2, sort_keys=True))
 
     def getSymptomsDiff(self, crashInfo):
         symptomsDiff = []
@@ -221,9 +221,11 @@ class CrashSignature(object):
     def getSignatureUnifiedDiffTuples(self, crashInfo):
         diffTuples = []
 
-        newRawCrashSignature = self.fit(crashInfo)
-        oldLines = self.rawSignature.splitlines()
+        # go through dumps(loads()) to standardize the format.
+        # the dumps args here must match what is returned by `fit()`
+        oldLines = json.dumps(json.loads(self.rawSignature), indent=2, sort_keys=True).splitlines()
         newLines = []
+        newRawCrashSignature = self.fit(crashInfo)
         if newRawCrashSignature:
             newLines = newRawCrashSignature.rawSignature.splitlines()
         context = max(len(oldLines), len(newLines))

--- a/server/crashmanager/views.py
+++ b/server/crashmanager/views.py
@@ -703,6 +703,9 @@ def viewSignature(request, sigid):
 
     latestCrash = CrashEntry.objects.aggregate(latest=Max('id'))['latest']
 
+    # standardize formatting of the signature
+    bucket.signature = json.dumps(json.loads(bucket.signature), indent=2, sort_keys=True)
+
     return render(request, 'signatures/view.html', {'bucket': bucket, 'latestCrash': latestCrash})
 
 
@@ -718,7 +721,7 @@ def editSignature(request, sigid):
 
         # TODO: FIXME: Update bug here as well
         return __handleSignaturePost(request, bucket)
-    elif request.method == 'GET':
+    if request.method == 'GET':
         if sigid is not None:
             bucket = get_object_or_404(Bucket, pk=sigid)
             check_authorized_for_signature(request, bucket)
@@ -726,12 +729,13 @@ def editSignature(request, sigid):
             if 'fit' in request.GET:
                 entry = get_object_or_404(CrashEntry, pk=request.GET['fit'])
                 bucket.signature = bucket.getSignature().fit(entry.getCrashInfo())
+            else:
+                # standardize formatting of the signature
+                # this is the same format returned by `fit()`
+                bucket.signature = json.dumps(json.loads(bucket.signature), indent=2, sort_keys=True)
 
             return render(request, 'signatures/edit.html', {'bucket': bucket})
-        else:
-            raise SuspiciousOperation
-    else:
-        raise SuspiciousOperation
+    raise SuspiciousOperation
 
 
 def linkSignature(request, sigid):


### PR DESCRIPTION
This was resulting in extra diff lines when using /try/crashid/ since migration to Python 3.