### PR TITLE
Add taskmanager to INSTALLED_APPS by default.

### DIFF
--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -49,7 +49,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'ec2spotmanager',
     'crashmanager',
-    #'taskmanager',
+    'taskmanager',
     'covmanager',
     'rest_framework',
     'rest_framework.authtoken',

--- a/server/server/settings_test.py
+++ b/server/server/settings_test.py
@@ -1,3 +1,2 @@
 from .settings import *  # noqa
-INSTALLED_APPS = tuple(list(INSTALLED_APPS) + ["taskmanager"])  # noqa
 TC_ROOT_URL = ""  # must be set for taskmanager tests


### PR DESCRIPTION
It is still disabled by the default user permissions, since this is not likely to be useful unless you have permission to run tasks in a Taskcluster deployment.

Fixes #604 