### PR TITLE
Improve the REST API

### DIFF
--- a/server/crashmanager/serializers.py
+++ b/server/crashmanager/serializers.py
@@ -45,7 +45,7 @@ class CrashEntrySerializer(serializers.ModelSerializer):
     class Meta:
         model = CrashEntry
         fields = (
-            'rawStdout', 'rawStderr', 'rawCrashData', 'metadata',
+            'rawStdout', 'rawStderr', 'rawCrashData', 'metadata', 'created', 'triagedOnce',
             'testcase', 'testcase_ext', 'testcase_size', 'testcase_quality', 'testcase_isbinary',
             'platform', 'product', 'product_version', 'os', 'client', 'tool',
             'env', 'args', 'bucket', 'id', 'shortSignature', 'crashAddress',

--- a/server/crashmanager/tests/test_crashes_rest.py
+++ b/server/crashmanager/tests/test_crashes_rest.py
@@ -10,12 +10,12 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 '''
 from __future__ import unicode_literals
+from datetime import datetime
 import json
 import logging
 import os.path
 import pytest
 import requests
-from django.contrib.auth.models import User
 from crashmanager.models import CrashEntry, TestCase as cmTestCase
 
 try:
@@ -24,71 +24,248 @@ except ImportError:
     from mock import Mock, patch
 
 
+# What should be allowed:
+#
+# +--------+------+----------+---------+---------+--------------+-------------------+------------+-------------------+
+# |        |      |          | no auth | no perm | unrestricted | unrestricted,     | restricted | restricted,       |
+# |        |      |          |         |         |              | ignore_toolfilter |            | ignore_toolfilter |
+# +--------+------+----------+---------+---------+--------------+-------------------+------------+-------------------+
+# | GET    | /    | list     | 401     | 403     | toolfilter   | all               | toolfilter | toolfilter        |
+# |        +------+----------+---------+---------+--------------+-------------------+------------+-------------------+
+# |        | /id/ | retrieve | 401     | 403     | all          | all               | toolfilter | toolfilter        |
+# +--------+------+----------+---------+---------+--------------+-------------------+------------+-------------------+
+# | POST   | /    | create   | 401     | 403     | all          | all               | all        | all               |
+# |        +------+----------+---------+---------+--------------+-------------------+------------+-------------------+
+# |        | /id/ | -        | 401     | 403     | 405          | 405               | 405        | 405               |
+# +--------+------+----------+---------+---------+--------------+-------------------+------------+-------------------+
+# | PUT    | /    | -        | 401     | 403     | 405          | 405               | 405        | 405               |
+# |        +------+----------+---------+---------+--------------+-------------------+------------+-------------------+
+# |        | /id/ | -        | 401     | 403     | 405          | 405               | 405        | 405               |
+# +--------+------+----------+---------+---------+--------------+-------------------+------------+-------------------+
+# | PATCH  | /    | -        | 401     | 403     | 405          | 405               | 405        | 405               |
+# |        +------+----------+---------+---------+--------------+-------------------+------------+-------------------+
+# |        | /id/ | update   | 401     | 403     | all          | all               | 405        | 405               |
+# +--------+------+----------+---------+---------+--------------+-------------------+------------+-------------------+
+# | DELETE | /    | -        | 401     | 403     | 405          | 405               | 405        | 405               |
+# |        +------+----------+---------+---------+--------------+-------------------+------------+-------------------+
+# |        | /id/ | delete   | 401     | 403     | all (TODO)   | all (TODO)        | 405        | 405               |
+# +--------+------+----------+---------+---------+--------------+-------------------+------------+-------------------+
+
+
 LOG = logging.getLogger("fm.crashmanager.tests.crashes.rest")
-pytestmark = pytest.mark.usefixtures("crashmanager_test")  # pylint: disable=invalid-name
 
 
-def test_rest_crashes_no_auth(api_client):
-    """must yield forbidden without authentication"""
-    url = '/crashmanager/rest/crashes/'
-    assert api_client.get(url).status_code == requests.codes['unauthorized']
-    assert api_client.post(url, {}).status_code == requests.codes['unauthorized']
-    assert api_client.put(url, {}).status_code == requests.codes['unauthorized']
-    assert api_client.patch(url, {}).status_code == requests.codes['unauthorized']
-    assert api_client.delete(url, {}).status_code == requests.codes['unauthorized']
+@pytest.mark.parametrize("method", ["delete", "get", "patch", "post", "put"])
+@pytest.mark.parametrize("url", ["/crashmanager/rest/crashes/", "/crashmanager/rest/crashes/1/"])
+def test_rest_crashes_no_auth(db, api_client, method, url):
+    """must yield unauthorized without authentication"""
+    assert getattr(api_client, method)(url, {}).status_code == requests.codes['unauthorized']
 
 
-def test_rest_crashes_no_perm(api_client):
+@pytest.mark.parametrize("method", ["delete", "get", "patch", "post", "put"])
+@pytest.mark.parametrize("url", ["/crashmanager/rest/crashes/", "/crashmanager/rest/crashes/1/"])
+def test_rest_crashes_no_perm(user_noperm, api_client, method, url):
     """must yield forbidden without permission"""
-    url = '/crashmanager/rest/crashes/'
-    user = User.objects.get(username='test-noperm')
-    api_client.force_authenticate(user=user)
-    assert api_client.get(url).status_code == requests.codes['forbidden']
-    assert api_client.post(url, {}).status_code == requests.codes['forbidden']
-    assert api_client.put(url, {}).status_code == requests.codes['forbidden']
-    assert api_client.patch(url, {}).status_code == requests.codes['forbidden']
-    assert api_client.delete(url, {}).status_code == requests.codes['forbidden']
+    assert getattr(api_client, method)(url, {}).status_code == requests.codes['forbidden']
 
 
-def test_rest_crashes_auth(api_client):
-    """test that authenticated requests work"""
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    resp = api_client.get('/crashmanager/rest/crashes/')
+@pytest.mark.parametrize("method, url, user", [
+    ("delete", "/crashmanager/rest/crashes/", "normal"),
+    ("delete", "/crashmanager/rest/crashes/", "restricted"),
+    ("delete", "/crashmanager/rest/crashes/1/", "normal"),  # TODO: this should be allowed, but hasn't been implemented
+    ("delete", "/crashmanager/rest/crashes/1/", "restricted"),
+    ("patch", "/crashmanager/rest/crashes/", "normal"),
+    ("patch", "/crashmanager/rest/crashes/", "restricted"),
+    ("patch", "/crashmanager/rest/crashes/1/", "restricted"),
+    ("post", "/crashmanager/rest/crashes/1/", "normal"),
+    ("post", "/crashmanager/rest/crashes/1/", "restricted"),
+    ("put", "/crashmanager/rest/crashes/", "normal"),
+    ("put", "/crashmanager/rest/crashes/", "restricted"),
+    ("put", "/crashmanager/rest/crashes/1/", "normal"),
+    ("put", "/crashmanager/rest/crashes/1/", "restricted"),
+], indirect=["user"])
+def test_rest_crashes_methods(api_client, user, method, url):
+    """must yield method-not-allowed for unsupported methods"""
+    assert getattr(api_client, method)(url, {}).status_code == requests.codes['method_not_allowed']
+
+
+def _compare_rest_result_to_crash(result, crash, raw=True):
+    expected_fields = {
+        'args', 'bucket', 'client', 'env', 'id', 'metadata', 'os', 'platform',
+        'product', 'product_version',
+        'testcase', 'testcase_isbinary', 'testcase_quality', 'testcase_size', 'tool',
+        'shortSignature', 'crashAddress', 'triagedOnce', 'created',
+    }
+    if raw:
+        expected_fields |= {'rawCrashData', 'rawStderr', 'rawStdout'}
+    assert set(result) == expected_fields
+    for key, value in result.items():
+        if key == "testcase":
+            continue
+        attrs = {"client": "client_name",
+                 "bucket": "bucket_pk",
+                 "os": "os_name",
+                 "platform": "platform_name",
+                 "product": "product_name",
+                 "testcase_isbinary": "testcase_isBinary",
+                 "tool": "tool_name"}.get(key, key)
+        obj = crash
+        for attr in attrs.split("_"):
+            if obj is not None:
+                obj = getattr(obj, attr)
+        if isinstance(obj, datetime):
+            obj = obj.isoformat().replace("+00:00", "Z")
+        assert value == obj
+
+
+def _compare_created_data_to_crash(data, crash, crash_address=None, short_signature=None):
+    for field in ('rawStdout', 'rawStderr', 'rawCrashData'):
+        assert getattr(crash, field) == data[field].strip()
+    if 'testcase' in data:
+        assert os.path.splitext(crash.testcase.test.path)[1].lstrip('.') == data['testcase_ext']
+        with open(crash.testcase.test.path) as fp:
+            assert fp.read() == data['testcase']
+        assert crash.testcase.isBinary == data['testcase_isbinary']
+        assert crash.testcase.quality == data['testcase_quality']
+    else:
+        assert crash.testcase is None
+    for field in ('platform', 'product', 'os', 'client', 'tool'):
+        assert getattr(crash, field).name == data[field]
+    assert crash.product.version == data['product_version']
+    if crash_address is not None:
+        assert crash.crashAddress == crash_address
+    if short_signature is not None:
+        assert crash.shortSignature == short_signature
+
+
+@pytest.mark.parametrize("user", ["normal", "restricted"], indirect=True)
+@pytest.mark.parametrize("ignore_toolfilter", [True, False])
+@pytest.mark.parametrize("include_raw", [True, False])
+def test_rest_crashes_list(api_client, user, cm, ignore_toolfilter, include_raw):
+    """test that list returns the right crashes"""
+    # if restricted or normal, must only list crashes in toolfilter
+    buckets = [cm.create_bucket(shortDescription="bucket #1"), None]
+    testcases = [cm.create_testcase("test3.txt", quality=5),
+                 cm.create_testcase("test4.txt", quality=5)]
+    tools = ["tool2", "tool1"]
+    crashes = [cm.create_crash(shortSignature="crash #%d" % (i + 1),
+                               client="client #%d" % (i + 1),
+                               os="os #%d" % (i + 1),
+                               product="product #%d" % (i + 1),
+                               product_version="%d" % (i + 1),
+                               platform="platform #%d" % (i + 1),
+                               tool=tools[i],
+                               bucket=buckets[i],
+                               testcase=testcases[i])
+               for i in range(2)]
+    # Create toolfilter, check that query returns only tool-filtered crashes
+    cm.create_toolfilter('tool2', user=user.username)
+    params = {}
+    if ignore_toolfilter:
+        params["ignore_toolfilter"] = "1"
+    if not include_raw:
+        params["include_raw"] = "0"
+    resp = api_client.get("/crashmanager/rest/crashes/", params)
     LOG.debug(resp)
     assert resp.status_code == requests.codes['ok']
+    expected = 2 if ignore_toolfilter and user.username == "test" else 1
+    assert resp.status_code == requests.codes['ok']
+    resp = json.loads(resp.content.decode('utf-8'))
+    assert set(resp) == {'count', 'next', 'previous', 'results'}
+    assert resp['count'] == expected
+    assert resp['next'] is None
+    assert resp['previous'] is None
+    assert len(resp['results']) == expected
+    for result, crash in zip(resp['results'], crashes[:expected]):
+        _compare_rest_result_to_crash(result, crash, raw=include_raw)
 
 
-def test_rest_crashes_patch(api_client):
-    """patch should not be allowed"""
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    resp = api_client.patch('/crashmanager/rest/crashes/')
+@pytest.mark.parametrize("user", ["normal", "restricted"], indirect=True)
+@pytest.mark.parametrize("ignore_toolfilter", [True, False])
+@pytest.mark.parametrize("include_raw", [True, False])
+def test_rest_crashes_retrieve(api_client, user, cm, ignore_toolfilter, include_raw):
+    """test that retrieve returns the right crash"""
+    # if restricted or normal, must only list crashes in toolfilter
+    buckets = [cm.create_bucket(shortDescription="bucket #1"), None]
+    testcases = [cm.create_testcase("test3.txt", quality=5),
+                 cm.create_testcase("test4.txt", quality=5)]
+    tools = ["tool2", "tool1"]
+    crashes = [cm.create_crash(shortSignature="crash #%d" % (i + 1),
+                               client="client #%d" % (i + 1),
+                               os="os #%d" % (i + 1),
+                               product="product #%d" % (i + 1),
+                               product_version="%d" % (i + 1),
+                               platform="platform #%d" % (i + 1),
+                               tool=tools[i],
+                               bucket=buckets[i],
+                               testcase=testcases[i])
+               for i in range(2)]
+    # Create toolfilter, check that query returns only tool-filtered crashes
+    cm.create_toolfilter('tool2', user=user.username)
+    params = {}
+    if ignore_toolfilter:
+        params["ignore_toolfilter"] = "1"
+    if not include_raw:
+        params["include_raw"] = "0"
+    for i, crash in enumerate(crashes):
+        resp = api_client.get("/crashmanager/rest/crashes/%d/" % crash.pk, params)
+        LOG.debug(resp)
+        allowed = user.username == "test" or tools[i] == "tool2"
+        if not allowed:
+            assert resp.status_code == requests.codes['not_found']
+        else:
+            status_code = resp.status_code
+            resp = resp.json()
+            assert status_code == requests.codes['ok'], resp['detail']
+            _compare_rest_result_to_crash(resp, crash, raw=include_raw)
+
+
+@pytest.mark.parametrize("user, expected, toolfilter", [
+    ("normal", 3, None),
+    ("restricted", None, None),
+    ("restricted", 3, "tool1"),
+], indirect=["user"])
+def test_rest_crashes_list_query(api_client, cm, user, expected, toolfilter):
+    """test that crashes can be queried"""
+    buckets = [cm.create_bucket(shortDescription="bucket #1"), None, None, None]
+    testcases = [cm.create_testcase("test1.txt", quality=5),
+                 cm.create_testcase("test2.txt", quality=0),
+                 cm.create_testcase("test3.txt", quality=5),
+                 cm.create_testcase("test4.txt", quality=5)]
+    tools = ["tool1", "tool1", "tool2", "tool1"]
+    crashes = [cm.create_crash(shortSignature="crash #%d" % (i + 1),
+                               client="client #%d" % (i + 1),
+                               os="os #%d" % (i + 1),
+                               product="product #%d" % (i + 1),
+                               product_version="%d" % (i + 1),
+                               platform="platform #%d" % (i + 1),
+                               tool=tools[i],
+                               bucket=buckets[i],
+                               testcase=testcases[i])
+               for i in range(4)]
+    if toolfilter is not None:
+        cm.create_toolfilter(toolfilter, user=user.username)
+    resp = api_client.get('/crashmanager/rest/crashes/',
+                          {"query": json.dumps({"op": "AND",
+                                                "bucket": None,
+                                                "testcase__quality": 5,
+                                                "tool__name__in": ["tool1"]})})
     LOG.debug(resp)
-    assert resp.status_code == requests.codes['method_not_allowed']
+    assert resp.status_code == requests.codes['ok']
+    resp = json.loads(resp.content.decode('utf-8'))
+    assert set(resp) == {'count', 'next', 'previous', 'results'}
+    assert resp['count'] == (0 if expected is None else 1)
+    assert resp['next'] is None
+    assert resp['previous'] is None
+    assert len(resp['results']) == resp['count']
+    if expected is not None:
+        _compare_rest_result_to_crash(resp['results'][0], crashes[expected])
 
 
-def test_rest_crashes_put(api_client):
-    """put should not be allowed"""
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    resp = api_client.put('/crashmanager/rest/crashes/')
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['method_not_allowed']
-
-
-def test_rest_crashes_delete(api_client):
-    """delete should not be allowed"""
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    resp = api_client.delete('/crashmanager/rest/crashes/')
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['method_not_allowed']
-
-
-def test_rest_crashes_report_crash(api_client):
-    """test that crash reporting works"""
-    data = {
+@pytest.mark.parametrize("user", ["normal", "restricted"], indirect=True)
+@pytest.mark.parametrize("data", [
+    # simple create
+    {
         'rawStdout': 'data on\nstdout',
         'rawStderr': 'data on\nstderr',
         'rawCrashData': 'some\tcrash\ndata\n',
@@ -101,28 +278,10 @@ def test_rest_crashes_report_crash(api_client):
         'product_version': 'badf00d',
         'os': 'linux',
         'client': 'client1',
-        'tool': 'tool1'}
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    resp = api_client.post('/crashmanager/rest/crashes/', data=data)
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['created']
-    crash = CrashEntry.objects.get()
-    for field in ('rawStdout', 'rawStderr', 'rawCrashData'):
-        assert getattr(crash, field) == data[field].strip()
-    assert os.path.splitext(crash.testcase.test.path)[1].lstrip('.') == data['testcase_ext']
-    with open(crash.testcase.test.path) as fp:
-        assert fp.read() == data['testcase']
-    assert crash.testcase.isBinary == data['testcase_isbinary']
-    assert crash.testcase.quality == data['testcase_quality']
-    for field in ('platform', 'product', 'os', 'client', 'tool'):
-        assert getattr(crash, field).name == data[field]
-    assert crash.product.version == data['product_version']
-
-
-def test_rest_crashes_report_crash_no_test(api_client):
-    """test that crash reporting works with no testcase"""
-    data = {
+        'tool': 'tool1',
+    },
+    # crash reporting works with no testcase
+    {
         'rawStdout': 'data on\nstdout',
         'rawStderr': 'data on\nstderr',
         'rawCrashData': 'some\ncrash\ndata',
@@ -131,24 +290,10 @@ def test_rest_crashes_report_crash_no_test(api_client):
         'product_version': 'badf00d',
         'os': 'linux',
         'client': 'client1',
-        'tool': 'tool1'}
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    resp = api_client.post('/crashmanager/rest/crashes/', data=data)
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['created']
-    crash = CrashEntry.objects.get()
-    for field in ('rawStdout', 'rawStderr', 'rawCrashData'):
-        assert getattr(crash, field) == data[field]
-    assert crash.testcase is None
-    for field in ('platform', 'product', 'os', 'client', 'tool'):
-        assert getattr(crash, field).name == data[field]
-    assert crash.product.version == data['product_version']
-
-
-def test_rest_crashes_report_crash_empty(api_client):
-    """test that crash reporting works with empty fields where allowed"""
-    data = {
+        'tool': 'tool1',
+    },
+    # crash reporting works with empty fields where allowed
+    {
         'rawStdout': '',
         'rawStderr': '',
         'rawCrashData': '',
@@ -161,26 +306,19 @@ def test_rest_crashes_report_crash_empty(api_client):
         'product_version': '',
         'os': 'x',
         'client': 'x',
-        'tool': 'x'}
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
+        'tool': 'x',
+    },
+])
+def test_rest_crashes_report_crash(api_client, user, data):
+    """test that crash reporting works"""
     resp = api_client.post('/crashmanager/rest/crashes/', data=data)
     LOG.debug(resp)
     assert resp.status_code == requests.codes['created']
     crash = CrashEntry.objects.get()
-    for field in ('rawStdout', 'rawStderr', 'rawCrashData'):
-        assert getattr(crash, field) == data[field]
-    assert os.path.splitext(crash.testcase.test.path)[1].lstrip('.') == data['testcase_ext']
-    with open(crash.testcase.test.path) as fp:
-        assert fp.read() == data['testcase']
-    assert crash.testcase.isBinary == data['testcase_isbinary']
-    assert crash.testcase.quality == data['testcase_quality']
-    for field in ('platform', 'product', 'os', 'client', 'tool'):
-        assert getattr(crash, field).name == data[field]
-    assert crash.product.version == data['product_version']
+    _compare_created_data_to_crash(data, crash)
 
 
-def test_rest_crashes_report_crash_long(api_client):
+def test_rest_crashes_report_crash_long(api_client, user_normal):
     """test that crash reporting works with fields interpreted as `long` in python 2"""
     data = {
         'rawStdout': '',
@@ -235,274 +373,58 @@ $1 = {si_signo = 11, si_errno = 0, si_code = 2, _sigfault = {si_addr = 0xf705700
         'os': 'linux',
         'client': 'x',
         'tool': 'x'}
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
     resp = api_client.post('/crashmanager/rest/crashes/', data=data)
     LOG.debug(resp)
     assert resp.status_code == requests.codes['created']
     crash = CrashEntry.objects.get()
-    for field in ('rawStdout', 'rawStderr', 'rawCrashData'):
-        assert getattr(crash, field) == data[field].strip()
-    assert os.path.splitext(crash.testcase.test.path)[1].lstrip('.') == data['testcase_ext']
-    with open(crash.testcase.test.path) as fp:
-        assert fp.read() == data['testcase']
-    assert crash.testcase.isBinary == data['testcase_isbinary']
-    assert crash.testcase.quality == data['testcase_quality']
-    for field in ('platform', 'product', 'os', 'client', 'tool'):
-        assert getattr(crash, field).name == data[field]
-    assert crash.product.version == data['product_version']
-    assert crash.crashAddress == '0xf7056fff'
+    _compare_created_data_to_crash(data, crash, crash_address='0xf7056fff')
 
 
-def test_rest_crashes_query_crash(api_client, cm):
-    """test that crashes can be queried"""
-    buckets = [cm.create_bucket(shortDescription="bucket #1"), None, None, None]
-    testcases = [cm.create_testcase("test1.txt", quality=5),
-                 cm.create_testcase("test2.txt", quality=0),
-                 cm.create_testcase("test3.txt", quality=5),
-                 cm.create_testcase("test4.txt", quality=5)]
-    tools = ["tool1", "tool1", "tool2", "tool1"]
-    crashes = [cm.create_crash(shortSignature="crash #%d" % (i + 1),
-                               client="client #%d" % (i + 1),
-                               os="os #%d" % (i + 1),
-                               product="product #%d" % (i + 1),
-                               product_version="%d" % (i + 1),
-                               platform="platform #%d" % (i + 1),
-                               tool=tools[i],
-                               bucket=buckets[i],
-                               testcase=testcases[i])
-               for i in range(4)]
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    resp = api_client.get('/crashmanager/rest/crashes/',
-                          {"query": json.dumps({"op": "AND",
-                                                "bucket": None,
-                                                "testcase__quality": 5,
-                                                "tool__name__in": ["tool1"]})})
+@patch('crashmanager.models.CrashEntry.save', new=Mock(side_effect=RuntimeError("crashentry failing intentionally")))
+def test_rest_crashes_report_bad_crash_removes_testcase(api_client, user_normal):
+    """test that reporting a bad crash doesn't leave an orphaned testcase"""
+    data = {
+        'rawStdout': 'data on\nstdout',
+        'rawStderr': 'data on\nstderr',
+        'rawCrashData': 'some\tcrash\ndata\n',
+        'testcase': 'foo();\ntest();',
+        'testcase_isbinary': False,
+        'testcase_quality': 0,
+        'testcase_ext': 'js',
+        'platform': 'x86',
+        'product': 'mozilla-central',
+        'product_version': 'badf00d',
+        'os': 'linux',
+        'client': 'client1',
+        'tool': 'tool1'}
+    with pytest.raises(RuntimeError):
+        api_client.post('/crashmanager/rest/crashes/', data=data)
+    assert not CrashEntry.objects.exists()
+    assert not cmTestCase.objects.exists()
+
+
+def test_rest_crashes_report_crash_long_sig(api_client, user_normal):
+    """test that crash reporting works with an assertion message too long for shortSignature"""
+    data = {
+        'rawStdout': 'data on\nstdout',
+        'rawStderr': 'data on\nstderr',
+        'rawCrashData': 'Assertion failure: ' + ('A' * 4096),
+        'platform': 'x86',
+        'product': 'mozilla-central',
+        'product_version': 'badf00d',
+        'os': 'linux',
+        'client': 'client1',
+        'tool': 'tool1'}
+    resp = api_client.post('/crashmanager/rest/crashes/', data=data)
     LOG.debug(resp)
-    assert resp.status_code == requests.codes['ok']
-    resp = json.loads(resp.content.decode('utf-8'))
-    assert set(resp.keys()) == {'count', 'next', 'previous', 'results'}
-    assert resp['count'] == 1
-    assert resp['next'] is None
-    assert resp['previous'] is None
-    assert len(resp['results']) == 1
-    resp = resp['results'][0]
-    assert set(resp.keys()) == {
-        'args', 'bucket', 'client', 'env', 'id', 'metadata', 'os', 'platform',
-        'product', 'product_version', 'rawCrashData', 'rawStderr', 'rawStdout',
-        'testcase', 'testcase_isbinary', 'testcase_quality', 'testcase_size', 'tool',
-        'shortSignature', 'crashAddress',
-    }
-    for key, value in resp.items():
-        if key == "testcase":
-            continue
-        attrs = {"client": "client_name",
-                 "os": "os_name",
-                 "platform": "platform_name",
-                 "product": "product_name",
-                 "testcase_isbinary": "testcase_isBinary",
-                 "tool": "tool_name"}.get(key, key)
-        result = crashes[3]
-        for attr in attrs.split("_"):
-            result = getattr(result, attr)
-        assert value == result
-
-    # Repeat the same with a restricted user, check that query returns 403
-    user = User.objects.get(username='test-restricted')
-    api_client.force_authenticate(user=user)
-    resp = api_client.get('/crashmanager/rest/crashes/',
-                          {"query": json.dumps({"op": "AND",
-                                                "bucket": None,
-                                                "testcase__quality": 5,
-                                                "tool__name__in": ["tool1"]})})
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['forbidden']
+    assert resp.status_code == requests.codes['created']
+    crash = CrashEntry.objects.get()
+    expected = ('Assertion failure: ' + ('A' * 4096))[:CrashEntry._meta.get_field('shortSignature').max_length]
+    _compare_created_data_to_crash(data, crash, short_signature=expected)
 
 
-def test_rest_crashes_list_noraw(api_client, cm):
-    """test that crashes can be listed without raw fields"""
-    testcase = cm.create_testcase("test1.txt", quality=5)
-    crash = cm.create_crash(shortSignature="crash #1",
-                            client="client #1",
-                            os="os #1",
-                            product="product #1",
-                            product_version="1",
-                            platform="platform #1",
-                            tool="tool1",
-                            bucket=None,
-                            testcase=testcase)
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    resp = api_client.get('/crashmanager/rest/crashes/', {'include_raw': '0'})
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['ok']
-    resp = json.loads(resp.content.decode('utf-8'))
-    assert set(resp.keys()) == {'count', 'next', 'previous', 'results'}
-    assert resp['count'] == 1
-    assert resp['next'] is None
-    assert resp['previous'] is None
-    assert len(resp['results']) == 1
-    resp = resp['results'][0]
-    assert set(resp.keys()) == {
-        'args', 'bucket', 'client', 'env', 'id', 'metadata', 'os', 'platform',
-        'product', 'product_version', 'testcase', 'testcase_isbinary',
-        'testcase_quality', 'testcase_size', 'tool', 'shortSignature', 'crashAddress',
-    }
-    for key, value in resp.items():
-        if key == "testcase":
-            continue
-        attrs = {"client": "client_name",
-                 "os": "os_name",
-                 "platform": "platform_name",
-                 "product": "product_name",
-                 "testcase_isbinary": "testcase_isBinary",
-                 "tool": "tool_name"}.get(key, key)
-        result = crash
-        for attr in attrs.split("_"):
-            result = getattr(result, attr)
-        assert value == result
-
-
-def test_rest_crash_no_auth(api_client):
-    """must yield forbidden without authentication"""
-    url = '/crashmanager/rest/crashes/1/'
-    assert api_client.get(url).status_code == requests.codes['unauthorized']
-    assert api_client.post(url, {}).status_code == requests.codes['unauthorized']
-    assert api_client.put(url, {}).status_code == requests.codes['unauthorized']
-    assert api_client.patch(url, {}).status_code == requests.codes['unauthorized']
-    assert api_client.delete(url, {}).status_code == requests.codes['unauthorized']
-
-
-def test_rest_crash_no_perm(api_client):
-    """must yield forbidden without permission"""
-    user = User.objects.get(username='test-noperm')
-    api_client.force_authenticate(user=user)
-    url = '/crashmanager/rest/crashes/1/'
-    assert api_client.get(url).status_code == requests.codes['forbidden']
-    assert api_client.post(url, {}).status_code, requests.codes['forbidden']
-    assert api_client.put(url, {}).status_code, requests.codes['forbidden']
-    assert api_client.patch(url, {}).status_code, requests.codes['forbidden']
-    assert api_client.delete(url, {}).status_code, requests.codes['forbidden']
-
-
-def test_rest_crash_auth(api_client):
-    """test that authenticated requests work"""
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    resp = api_client.get('/crashmanager/rest/crashes/')
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['ok']
-
-
-def test_rest_crash_restricted(api_client):
-    """test that restricted users are rejected"""
-    user = User.objects.get(username='test-restricted')
-    api_client.force_authenticate(user=user)
-    resp = api_client.get('/crashmanager/rest/crashes/')
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['forbidden']
-
-
-def test_rest_crash_delete(api_client):
-    """delete should not be allowed"""
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    resp = api_client.delete('/crashmanager/rest/crashes/1/')
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['method_not_allowed']
-
-
-def test_rest_crash_put(api_client):
-    """put should not be allowed"""
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    resp = api_client.put('/crashmanager/rest/crashes/1/')
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['method_not_allowed']
-
-
-def test_rest_crash_post(api_client):
-    """post should not be allowed"""
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    resp = api_client.post('/crashmanager/rest/crashes/1/')
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['method_not_allowed']
-
-
-def test_rest_crash_get(api_client, cm):
-    """test that individual CrashEntry can be fetched"""
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    test = cm.create_testcase("test.txt", quality=0)
-    bucket = cm.create_bucket(shortDescription="bucket #1")
-    crash = cm.create_crash(shortSignature="crash #1",
-                            bucket=bucket,
-                            client="client #1",
-                            os="os #1",
-                            product="product #1",
-                            product_version="1",
-                            platform="platform #1",
-                            tool="tool #1",
-                            testcase=test)
-    resp = api_client.get('/crashmanager/rest/crashes/%d/' % crash.pk)
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['ok']
-    resp = json.loads(resp.content.decode('utf-8'))
-    assert set(resp.keys()) == {
-        'args', 'bucket', 'client', 'env', 'id', 'metadata', 'os', 'platform',
-        'product', 'product_version', 'rawCrashData', 'rawStderr', 'rawStdout',
-        'testcase', 'testcase_isbinary', 'testcase_size', 'testcase_quality', 'tool',
-        'shortSignature', 'crashAddress',
-    }
-    for key, value in resp.items():
-        if key == "testcase":
-            continue
-        attrs = {"client": "client_name",
-                 "os": "os_name",
-                 "bucket": "bucket_pk",
-                 "platform": "platform_name",
-                 "product": "product_name",
-                 "testcase_isbinary": "testcase_isBinary",
-                 "tool": "tool_name"}.get(key, key)
-        result = crash
-        for attr in attrs.split("_"):
-            result = getattr(result, attr)
-        assert value == result
-
-
-def test_rest_crash_get_restricted(api_client, cm):
-    """test that individual CrashEntry can be created but not fetched by restricted user"""
-    user = User.objects.get(username='test-restricted')
-    api_client.force_authenticate(user=user)
-    test = cm.create_testcase("test.txt", quality=0)
-    bucket = cm.create_bucket(shortDescription="bucket #1")
-    crash = cm.create_crash(shortSignature="crash #1",
-                            bucket=bucket,
-                            client="client #1",
-                            os="os #1",
-                            product="product #1",
-                            product_version="1",
-                            platform="platform #1",
-                            tool="tool #1",
-                            testcase=test)
-    resp = api_client.get('/crashmanager/rest/crashes/%d/' % crash.pk)
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['forbidden']
-
-    # Retry with unrestricted user and check that the entry has been created
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    resp = api_client.get('/crashmanager/rest/crashes/%d/' % crash.pk)
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['ok']
-
-
-def test_rest_crash_update(api_client, cm):
+def test_rest_crash_update(api_client, cm, user_normal):
     """test that only allowed fields of CrashEntry can be updated"""
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
     test = cm.create_testcase("test.txt", quality=0)
     bucket = cm.create_bucket(shortDescription="bucket #1")
     crash = cm.create_crash(shortSignature="crash #1",
@@ -528,10 +450,8 @@ def test_rest_crash_update(api_client, cm):
     assert test.quality == 5
 
 
-def test_rest_crash_update_restricted(api_client, cm):
+def test_rest_crash_update_restricted(api_client, cm, user_restricted):
     """test that restricted users cannot perform updates on CrashEntry"""
-    user = User.objects.get(username='test-restricted')
-    api_client.force_authenticate(user=user)
     test = cm.create_testcase("test.txt", quality=0)
     bucket = cm.create_bucket(shortDescription="bucket #1")
     crash = cm.create_crash(shortSignature="crash #1",
@@ -549,54 +469,4 @@ def test_rest_crash_update_restricted(api_client, cm):
     for field in fields:
         resp = api_client.patch('/crashmanager/rest/crashes/%d/' % crash.pk, {field: ""})
         LOG.debug(resp)
-        assert resp.status_code == requests.codes['forbidden']
-
-
-@patch('crashmanager.models.CrashEntry.save', new=Mock(side_effect=RuntimeError("crashentry failing intentionally")))
-def test_rest_crashes_report_bad_crash_removes_testcase(api_client):
-    """test that reporting a bad crash doesn't leave an orphaned testcase"""
-    data = {
-        'rawStdout': 'data on\nstdout',
-        'rawStderr': 'data on\nstderr',
-        'rawCrashData': 'some\tcrash\ndata\n',
-        'testcase': 'foo();\ntest();',
-        'testcase_isbinary': False,
-        'testcase_quality': 0,
-        'testcase_ext': 'js',
-        'platform': 'x86',
-        'product': 'mozilla-central',
-        'product_version': 'badf00d',
-        'os': 'linux',
-        'client': 'client1',
-        'tool': 'tool1'}
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    with pytest.raises(RuntimeError):
-        api_client.post('/crashmanager/rest/crashes/', data=data)
-    assert not CrashEntry.objects.exists()
-    assert not cmTestCase.objects.exists()
-
-
-def test_rest_crashes_report_crash_long_sig(api_client):
-    """test that crash reporting works with no testcase"""
-    data = {
-        'rawStdout': 'data on\nstdout',
-        'rawStderr': 'data on\nstderr',
-        'rawCrashData': 'Assertion failure: ' + ('A' * 4096),
-        'platform': 'x86',
-        'product': 'mozilla-central',
-        'product_version': 'badf00d',
-        'os': 'linux',
-        'client': 'client1',
-        'tool': 'tool1'}
-    user = User.objects.get(username='test')
-    api_client.force_authenticate(user=user)
-    resp = api_client.post('/crashmanager/rest/crashes/', data=data)
-    LOG.debug(resp)
-    assert resp.status_code == requests.codes['created']
-    crash = CrashEntry.objects.get()
-    for field in ('rawStdout', 'rawStderr', 'rawCrashData'):
-        assert getattr(crash, field) == data[field]
-    assert crash.testcase is None
-    expected = ('Assertion failure: ' + ('A' * 4096))[:CrashEntry._meta.get_field('shortSignature').max_length]
-    assert crash.shortSignature == expected
+        assert resp.status_code == requests.codes['method_not_allowed']


### PR DESCRIPTION
* implement same toolfilter logic in API as in UI
* allow session authentication
* add remaining fields to crashes API: `created` & `triagedOnce`
* add ordering filter to both crashes & buckets APIs
* make error handling more consistent (4xx instead of 5xx)