### PR TITLE
[libFuzzer] Add argument for performing post crash transformations

### DIFF
--- a/misc/afl-libfuzzer/afl-libfuzzer-daemon.py
+++ b/misc/afl-libfuzzer/afl-libfuzzer-daemon.py
@@ -17,21 +17,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Ensure print() compatibility with Python 3
 from __future__ import print_function
 
-from Collector.Collector import Collector
-from FTB.ProgramConfiguration import ProgramConfiguration
-from FTB.Running.AutoRunner import AutoRunner
-from FTB.Signatures.CrashInfo import CrashInfo
-
-from S3Manager import S3Manager
-
 import argparse
 import collections
-from fasteners import InterProcessLock
 import os
-from pathlib import Path
 import re
 import shutil
-from six.moves import queue
 import stat
 import subprocess
 import sys
@@ -40,6 +30,16 @@ import threading
 import time
 import traceback
 import zipfile
+from pathlib import Path
+
+from fasteners import InterProcessLock
+from six.moves import queue
+
+from Collector.Collector import Collector
+from FTB.ProgramConfiguration import ProgramConfiguration
+from FTB.Running.AutoRunner import AutoRunner
+from FTB.Signatures.CrashInfo import CrashInfo
+from S3Manager import S3Manager
 
 haveFFPuppet = True
 try:

--- a/misc/afl-libfuzzer/afl-libfuzzer-daemon.py
+++ b/misc/afl-libfuzzer/afl-libfuzzer-daemon.py
@@ -567,7 +567,6 @@ def scan_crashes(base_dir, collector, cmdline_path=None, env_path=None, test_pat
                     submission = apply_transform(transform, crash_file)
                 except Exception as e:
                     print(e.args[1], file=sys.stderr)
-                    return 2
 
             if test_idx is not None:
                 cmdline[test_idx] = orig_test_arg.replace('@@', crash_file)
@@ -1422,7 +1421,6 @@ def main(argv=None):
                         testcase = apply_transform(opts.transform, testcase)
                     except Exception as e:
                         print(e.args[1], file=sys.stderr)
-                        return 2
 
                 # If we run in local mode (no --fuzzmanager specified), then we just continue after each crash
                 if not opts.fuzzmanager:

--- a/misc/afl-libfuzzer/afl-libfuzzer-daemon.py
+++ b/misc/afl-libfuzzer/afl-libfuzzer-daemon.py
@@ -17,8 +17,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Ensure print() compatibility with Python 3
 from __future__ import print_function
 
-from zipfile import ZipFile
-
 from Collector.Collector import Collector
 from FTB.ProgramConfiguration import ProgramConfiguration
 from FTB.Running.AutoRunner import AutoRunner
@@ -30,6 +28,7 @@ import argparse
 import collections
 from fasteners import InterProcessLock
 import os
+from pathlib import Path
 import re
 import shutil
 from six.moves import queue
@@ -40,6 +39,7 @@ import tempfile
 import threading
 import time
 import traceback
+import zipfile
 
 haveFFPuppet = True
 try:
@@ -659,11 +659,10 @@ def apply_transform(script_path, testcase_path):
             raise Exception("Transformation script did not generate any files.  Aborting...")
 
         archive_path = testcase_path + ".zip"
-        with ZipFile(archive_path, 'w') as archive:
-            archive.write(testcase_path)
-            for root, dirs, files in os.walk(output_path):
-                for file in files:
-                    archive.write(os.path.join(root, file))
+        with zipfile.ZipFile(archive_path, 'w', zipfile.ZIP_DEFLATED) as archive:
+            archive.write(testcase_path, os.path.basename(testcase_path))
+            for file in Path(output_path).rglob('*.*'):
+                archive.write(file, arcname=file.relative_to(output_path))
 
     return archive_path
 


### PR DESCRIPTION
This PR adds a single argument for applying a post crash transformation to the testcase.  The `--transform` argument expects a path to a binary file that will be run with the testcase path as an argument.