### PR TITLE
Use TextField instead of Charfield with oversized max_length

### DIFF
--- a/server/ec2spotmanager/migrations/0001_squashed_0013_add_gce_fields.py
+++ b/server/ec2spotmanager/migrations/0001_squashed_0013_add_gce_fields.py
@@ -50,7 +50,7 @@ class Migration(migrations.Migration):
                 ("status_code", models.IntegerField()),
                 (
                     "status_data",
-                    models.CharField(blank=True, max_length=4095, null=True),
+                    models.TextField(blank=True, null=True),
                 ),
                 (
                     "ec2_instance_id",
@@ -110,7 +110,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "ec2_instance_type",
-                    models.CharField(blank=True, max_length=1023, null=True),
+                    models.TextField(blank=True, null=True),
                 ),
                 (
                     "ec2_image_name",
@@ -129,7 +129,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "ec2_userdata_macros",
-                    models.CharField(blank=True, max_length=4095, null=True),
+                    models.TextField(blank=True, null=True),
                 ),
                 (
                     "ec2_allowed_regions",
@@ -144,7 +144,7 @@ class Migration(migrations.Migration):
                 ("ec2_tags", models.CharField(blank=True, max_length=1023, null=True)),
                 (
                     "ec2_raw_config",
-                    models.CharField(blank=True, max_length=4095, null=True),
+                    models.TextField(blank=True, null=True),
                 ),
                 (
                     "parent",
@@ -305,7 +305,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="poolconfiguration",
             name="ec2_instance_types",
-            field=models.CharField(blank=True, max_length=4095, null=True),
+            field=models.TextField(blank=True, null=True),
         ),
         migrations.RenameField(
             model_name="instance", old_name="ec2_instance_id", new_name="instance_id",
@@ -364,12 +364,12 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="poolconfiguration",
             name="gce_args",
-            field=models.CharField(blank=True, max_length=4095, null=True),
+            field=models.TextField(blank=True, null=True),
         ),
         migrations.AddField(
             model_name="poolconfiguration",
             name="gce_cmd",
-            field=models.CharField(blank=True, max_length=4095, null=True),
+            field=models.TextField(blank=True, null=True),
         ),
         migrations.AddField(
             model_name="poolconfiguration",
@@ -389,7 +389,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="poolconfiguration",
             name="gce_env",
-            field=models.CharField(blank=True, max_length=4095, null=True),
+            field=models.TextField(blank=True, null=True),
         ),
         migrations.AddField(
             model_name="poolconfiguration",
@@ -404,11 +404,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="poolconfiguration",
             name="gce_machine_types",
-            field=models.CharField(blank=True, max_length=4095, null=True),
+            field=models.TextField(blank=True, null=True),
         ),
         migrations.AddField(
             model_name="poolconfiguration",
             name="gce_raw_config",
-            field=models.CharField(blank=True, max_length=4095, null=True),
+            field=models.TextField(blank=True, null=True),
         ),
     ]

--- a/server/ec2spotmanager/models.py
+++ b/server/ec2spotmanager/models.py
@@ -38,26 +38,26 @@ class PoolConfiguration(models.Model):
     instance_tags = models.CharField(max_length=1023, blank=True, null=True)
     ec2_key_name = models.CharField(max_length=255, blank=True, null=True)
     ec2_security_groups = models.CharField(max_length=255, blank=True, null=True)
-    ec2_instance_types = models.CharField(max_length=4095, blank=True, null=True)
+    ec2_instance_types = models.TextField(blank=True, null=True)
     ec2_image_name = models.CharField(max_length=255, blank=True, null=True)
     ec2_userdata_file = \
         models.FileField(storage=OverwritingStorage(location=getattr(settings, 'USERDATA_STORAGE', None)),
                          upload_to=get_storage_path, blank=True, null=True)
-    ec2_userdata_macros = models.CharField(max_length=4095, blank=True, null=True)
+    ec2_userdata_macros = models.TextField(blank=True, null=True)
     ec2_allowed_regions = models.CharField(max_length=1023, blank=True, null=True)
-    ec2_raw_config = models.CharField(max_length=4095, blank=True, null=True)
-    gce_machine_types = models.CharField(max_length=4095, blank=True, null=True)
+    ec2_raw_config = models.TextField(blank=True, null=True)
+    gce_machine_types = models.TextField(blank=True, null=True)
     gce_image_name = models.CharField(max_length=255, blank=True, null=True)
     gce_container_name = models.CharField(max_length=512, blank=True, null=True)
     gce_docker_privileged = models.BooleanField(default=False)
     gce_disk_size = models.IntegerField(blank=True, null=True)
-    gce_cmd = models.CharField(max_length=4095, blank=True, null=True)
-    gce_args = models.CharField(max_length=4095, blank=True, null=True)
-    gce_env = models.CharField(max_length=4095, blank=True, null=True)
+    gce_cmd = models.TextField(blank=True, null=True)
+    gce_args = models.TextField(blank=True, null=True)
+    gce_env = models.TextField(blank=True, null=True)
     # this is a special case that allows copying ec2_userdata_macros into gce_env during flatten()
     # we typically use userdata_macros to be the env vars provided to the userdata script
     gce_env_include_macros = models.BooleanField(default=False)
-    gce_raw_config = models.CharField(max_length=4095, blank=True, null=True)
+    gce_raw_config = models.TextField(blank=True, null=True)
 
     def __init__(self, *args, **kwargs):
         # These variables can hold temporarily deserialized data
@@ -345,7 +345,7 @@ class Instance(models.Model):
     pool = models.ForeignKey(InstancePool, blank=True, null=True, on_delete=models.deletion.CASCADE)
     hostname = models.CharField(max_length=255, blank=True, null=True)
     status_code = models.IntegerField()
-    status_data = models.CharField(max_length=4095, blank=True, null=True)
+    status_data = models.TextField(blank=True, null=True)
     instance_id = models.CharField(max_length=255, blank=True, null=True)
     region = models.CharField(max_length=255)
     zone = models.CharField(max_length=255)


### PR DESCRIPTION
Mysql does not support `CharField` (as `VARCHAR`) with a size over 255.

I simply updated the existing migration and relevant models to use TextField (no size limit anymore).

No need to run a migration on existing instances.