### PR TITLE
Update fixture to fix unit test using fuzzing-decision Pool parser

### DIFF
--- a/server/taskmanager/tests/fixtures/pool1/pool1.yml
+++ b/server/taskmanager/tests/fixtures/pool1/pool1.yml
@@ -18,3 +18,4 @@ preprocess: ""
 macros:
   ENVVAR1: "123456"
   ENVVAR2: 789abc
+run_as_admin: false


### PR DESCRIPTION
I got a unit test failure on both `dev-teklia` and `master` branch ([sample](https://community-tc.services.mozilla.com/tasks/ety_Fl2VQSiqMF6XlKoGJg/runs/0/logs/public/logs/live.log)).

It comes from [this commit](https://github.com/MozillaSecurity/orion/commit/5b4123c65587cdfb58ecee97bfbd32cf3a7b7d3a) on fuzzing-decision that introduces a new required parameter `run_as_admin`.

I simply updated the relevant fixture to fix the CI issue