### PR TITLE
Use v-pre to prevent Vue.js failure on special characters

### DIFF
--- a/server/crashmanager/templates/crashes/view.html
+++ b/server/crashmanager/templates/crashes/view.html
@@ -62,7 +62,7 @@
 	    <span class="glyphicon glyphicon-eye-open"></span>
             </button>
 	    <div id="stdout" class="accordian-body collapse">
-              <pre><code>{{ entry.rawStdout }}</code></pre>
+              <pre><code v-pre>{{ entry.rawStdout }}</code></pre>
             </div>
         </div>
         <br />
@@ -75,7 +75,7 @@
 	    <span class="glyphicon glyphicon-eye-open"></span>
             </button>
 	    <div id="stderr" class="accordian-body collapse">
-              <pre><code>{{ entry.rawStderr }}</code></pre>
+              <pre><code v-pre>{{ entry.rawStderr }}</code></pre>
             </div>
         </div>
         <br />
@@ -84,7 +84,7 @@
         {% if entry.rawCrashData %}
         <div class="field">
             <strong>Additional Crash Data</strong>
-            <pre><code class="language-bash">{{ entry.rawCrashData }}</code></pre>
+            <pre><code class="language-bash" v-pre>{{ entry.rawCrashData }}</code></pre>
         </div>
         <br />
         {% endif %}
@@ -95,7 +95,7 @@
             {% if entry.testcase.isBinary %}
             <br/>
             {% else %}
-            <pre><code>{{ entry.testcase.content.decode }}</code></pre>
+            <pre><code v-pre>{{ entry.testcase.content.decode }}</code></pre>
             {% endif %}
             <a href="{% url 'crashmanager:download_test' entry.pk %}" class="btn btn-success">Download</a>
         </div>
@@ -107,7 +107,7 @@
             <strong>Command-Line Arguments</strong>
             <br/>
             {% for arg in entry.argsList %}
-            <code>{{ arg }}</code>
+            <code v-pre>{{ arg }}</code>
             {% endfor %}
         </div>
         <br/>

--- a/server/crashmanager/templates/signatures/optimize.html
+++ b/server/crashmanager/templates/signatures/optimize.html
@@ -25,7 +25,7 @@
                 </td>
                 {% if forloop.counter == 1 %}
                 <td rowspan="{{ diff|length }}">
-                    <pre><code class="language-bash">{{ matchingEntries.0.crashinfo }}</code></pre>
+                    <pre><code class="language-bash" v-pre>{{ matchingEntries.0.crashinfo }}</code></pre>
 	    	</td>
                 {% endif %}
             </tr>

--- a/server/crashmanager/templates/signatures/try.html
+++ b/server/crashmanager/templates/signatures/try.html
@@ -24,7 +24,7 @@
                 </td>
                 {% if forloop.counter == 1 %}
                 <td rowspan="{{ diff|length }}">
-                    <pre><code class="language-bash">{{ entry.crashinfo }}</code></pre>
+                    <pre><code class="language-bash" v-pre>{{ entry.crashinfo }}</code></pre>
                 </td>
                 {% endif %}
             </tr>

--- a/server/crashmanager/templates/signatures/view.html
+++ b/server/crashmanager/templates/signatures/view.html
@@ -49,7 +49,7 @@
         </table>
 
         <strong>Signature</strong><br/>
-        <pre><code>{{ bucket.signature }}</code></pre>
+        <pre><code v-pre>{{ bucket.signature }}</code></pre>
 
         <div class="btn-group">
             <a href="{% url 'crashmanager:crashes' %}#bucket={{ bucket.pk }}" class="btn btn-default">Associated Crashes</a>


### PR DESCRIPTION
Closes #686 

Since Vue.js is now available directly at the project root, it was trying to compile the displayed code from `rawStdout` attribute on `CrashEntry` 107.

By using [`v-pre`](https://vuejs.org/v2/api/#v-pre) attribute on HTML elements potentially rendering code, we prevent Vue.js from misinterpreting data to be rendered.