### PR TITLE
Add back limited Taskmanager scraping

### DIFF
--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -359,6 +359,10 @@ REDIS_URL = 'redis://localhost:6379?db=0'  # unix sockets, use unix:///path/to/s
 #         'task': 'ec2spotmanager.cron.update_prices',
 #         'schedule': 15 * 60,
 #     },
+#     'Poll TaskManager tasks with missed pulses': {
+#         'task': 'taskmanager.cron.update_tasks',
+#         'schedule': 15 * 60,
+#     },
 #     'Cleanup expired TaskManager tasks': {
 #         'task': 'taskmanager.cron.delete_expired',
 #         'schedule': 5 * 60,

--- a/server/taskmanager/cron.py
+++ b/server/taskmanager/cron.py
@@ -2,11 +2,36 @@
 from __future__ import unicode_literals
 from datetime import datetime
 from logging import getLogger
+from django.conf import settings
 from django.utils import timezone
 from celeryconf import app
 
 
 LOG = getLogger("taskmanager.cron")
+
+
+@app.task(ignore_result=True)
+def update_tasks():
+    import taskcluster
+    from .models import Task
+    from .tasks import update_task
+
+    queue_svc = taskcluster.Queue({"rootUrl": settings.TC_ROOT_URL})
+    now = datetime.now(timezone.utc)
+
+    # this should never be required, but we seem to miss Task events
+    # in mozilla pulse sometimes.
+    # if we notice that a task is pending or running for longer than
+    # normal, try to update the task directly from taskcluster
+
+    for task_obj in Task.objects.filter(state__in=["pending", "running"]).select_related("pool"):
+        if task_obj.state == "running" and task_obj.created is not None and task_obj.pool is not None:
+            if task_obj.created + task_obj.pool.max_run_time >= now:
+                continue
+
+        status = queue_svc.status(task_obj.task_id)
+        status["runId"] = task_obj.run_id
+        update_task.delay(status)
 
 
 @app.task(ignore_result=True)

--- a/server/taskmanager/tasks.py
+++ b/server/taskmanager/tasks.py
@@ -102,12 +102,12 @@ def update_task(pulse_data):
         "started": run_obj.get("started"),
         "state": run_obj["state"],
     }
-    task_obj, created = Task.objects.update_or_create(
+    task_obj, _ = Task.objects.update_or_create(
         task_id=status["taskId"],
         run_id=run_id,
         defaults=defaults,
     )
-    if created:
+    if task_obj.created is None:
         # `created` field isn't available via pulse, so get it from Taskcluster
         queue_svc = taskcluster.Queue({"rootUrl": settings.TC_ROOT_URL})
         task = queue_svc.task(status["taskId"])

--- a/server/taskmanager/tasks.py
+++ b/server/taskmanager/tasks.py
@@ -36,7 +36,7 @@ def _get_or_create_pool(worker_type):
 
 @app.task(ignore_result=True)
 def update_pool_defns():
-    from fuzzing_decision.common.pool import PoolConfiguration
+    from fuzzing_decision.common.pool import PoolConfigLoader
     from .models import Pool, Task
 
     # don't remove pools while they have existing tasks
@@ -57,7 +57,7 @@ def update_pool_defns():
     )
     check_output(["git", "reset", "--hard", "FETCH_HEAD"], cwd=storage)
     for config_file in storage.glob("pool*.yml"):
-        pool_data = PoolConfiguration.from_file(config_file)
+        pool_data = PoolConfigLoader.from_file(config_file)
         defaults = {
             "pool_name": pool_data.name,
             "size": pool_data.tasks,


### PR DESCRIPTION
#649 added the ability to listen for mozillapulse updates rather than scraping Taskcluster all the time. This mostly works great, but we do miss updates occasionally. 

This adds scraping only for specific tasks that we already know about in the database and that are unresolved (pending/running).

Also fix a traceback seen when updating pools from fuzzing-tc-config.