### PR TITLE
Fix signature view template when bug provider urlTemplate is empty.

### DIFF
--- a/server/crashmanager/templates/signatures/view.html
+++ b/server/crashmanager/templates/signatures/view.html
@@ -18,7 +18,11 @@
             <tr><td>External Bug Status</td>
                 <td>
             {% if bucket.bug %}
+                {% if bucket.bug.externalType.urlTemplate %}
                 Reported as <a {% if bucket.bug.closed %}class="fixedbug"{% endif %} href="{{ bucket.bug.externalType.urlTemplate|varformat:bucket.bug.externalId }}" target="_blank">bug {{ bucket.bug.externalId }}</a>.
+                {% else %}
+                Reported as bug {{ bucket.bug.externalId }} on {{ bucket.bug.externalType.hostname }}
+                {% endif %}
             {% else %}
                 Unreported.
             {% endif %}


### PR DESCRIPTION
It would certainly be a good idea to ensure that the Bug provider forms do not allow empty values there (if needed) 