### PR TITLE
[taskmanager] Add logging and fix pool=null in some cases.

### DIFF
--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -230,6 +230,13 @@ LOGGING = {
             'maxBytes': 16777216,
             'formatter': 'simple'
         },
+        'taskmanager_logfile': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': os.path.join(LOG_DIR, 'taskmanager.log'),
+            'maxBytes': 16777216,
+            'formatter': 'simple'
+        },
         'mail_admins': {
             'level': 'ERROR',
             'class': 'django.utils.log.AdminEmailHandler',
@@ -257,6 +264,11 @@ LOGGING = {
         },
         'ec2spotmanager': {
             'handlers': ['ec2spotmanager_logfile'],
+            'propagate': True,
+            'level': 'INFO',
+        },
+        'taskmanager': {
+            'handlers': ['taskmanager_logfile'],
             'propagate': True,
             'level': 'INFO',
         },

--- a/server/taskmanager/management/commands/taskmanager_scrape_task_group.py
+++ b/server/taskmanager/management/commands/taskmanager_scrape_task_group.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+import functools
+from logging import getLogger
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management import BaseCommand  # noqa
+import taskcluster
+
+from ...tasks import _get_or_create_pool
+from ...models import Task
+
+
+LOG = getLogger("taskmanager.management.commands.scrape_group")
+
+
+def paginated(func, result_key):
+    """Wraps a Taskcluster API that returns a result like:
+    {
+       continuationToken: "",
+       result_key: [...]
+    }
+    This hides the process of re-requesting with continuationToken,
+    and yields the contents of `result_key`
+    """
+    @functools.wraps(func)
+    def _wrapped(*args, **kwds):
+        kwds = kwds.copy()
+        result = func(*args, **kwds)
+        while result.get("continuationToken"):
+            for sub in result[result_key]:
+                yield sub
+            kwds.setdefault("query", {})
+            kwds["query"]["continuationToken"] = result["continuationToken"]
+            result = func(*args, **kwds)
+        for sub in result[result_key]:
+            yield sub
+    return _wrapped
+
+
+class Command(BaseCommand):
+    help = "Scrape a task group and add created tasks to taskmanager"
+
+    def add_arguments(self, parser):
+        parser.add_argument('task_group')
+
+    def handle(self, *args, **options):
+        queue_svc = taskcluster.Queue({"rootUrl": settings.TC_ROOT_URL})
+        task_group_id = options["task_group"]
+
+        for task in paginated(queue_svc.listTaskGroup, "tasks")(task_group_id):
+            # the task group id is for the decision
+            # we only care about fuzzing tasks
+            if task["status"]["taskId"] == task_group_id:
+                continue
+
+            pool = _get_or_create_pool(task["status"]["workerType"])
+            if pool is None:
+                LOG.debug(
+                    "ignoring task %s update for workerType %s",
+                    task["status"]["taskId"],
+                    task["status"]["workerType"],
+                )
+                return
+
+            for run in task["status"]["runs"]:
+                _, created = Task.objects.update_or_create(
+                    task_id=task["status"]["taskId"],
+                    run_id=run["runId"],
+                    defaults={
+                        "decision_id": task_group_id,
+                        "created": task["task"]["created"],
+                        "expires": task["task"]["expires"],
+                        "resolved": run.get("resolved"),
+                        "started": run.get("started"),
+                        "state": run["state"],
+                        "pool": pool,
+                    },
+                )
+                LOG.info(
+                    "%s task %s run %d in pool %s/%s -> %s",
+                    "created" if created else "updated",
+                    task["status"]["taskId"],
+                    run["runId"],
+                    pool.pool_id,
+                    pool.platform,
+                    run["state"],
+                )

--- a/server/taskmanager/tasks.py
+++ b/server/taskmanager/tasks.py
@@ -11,7 +11,7 @@ from . import cron  # noqa ensure cron tasks get registered
 LOG = getLogger("taskmanager.tasks")
 
 
-def _get_or_create_pool(worker_type):
+def get_or_create_pool(worker_type):
     from .models import Pool
 
     if worker_type in settings.TC_EXTRA_POOLS:
@@ -95,7 +95,7 @@ def update_task(pulse_data):
     status = pulse_data["status"]
     run_id = pulse_data["runId"]
     run_obj = next(run for run in status["runs"] if run["runId"] == run_id)
-    pool = _get_or_create_pool(status["workerType"])
+    pool = get_or_create_pool(status["workerType"])
     if pool is None:
         LOG.debug(
             "ignoring task %s update for workerType %s",

--- a/server/taskmanager/tasks.py
+++ b/server/taskmanager/tasks.py
@@ -24,13 +24,16 @@ def _get_or_create_pool(worker_type):
         platform, pool_id = worker_type.split("-", 1)
         assert pool_id.startswith("pool")
 
-    pool, _ = Pool.objects.get_or_create(
+    pool, created = Pool.objects.get_or_create(
         pool_id=pool_id,
         platform=platform,
         defaults={
             "pool_name": pool_id,
         },
     )
+    if created:
+        LOG.info("created new pool %d for %s/%s", pool.id, platform, pool_id)
+
     return pool
 
 
@@ -93,6 +96,13 @@ def update_task(pulse_data):
     run_id = pulse_data["runId"]
     run_obj = next(run for run in status["runs"] if run["runId"] == run_id)
     pool = _get_or_create_pool(status["workerType"])
+    if pool is None:
+        LOG.debug(
+            "ignoring task %s update for workerType %s",
+            status["taskId"],
+            status["workerType"],
+        )
+        return
 
     defaults = {
         "decision_id": status["taskGroupId"],
@@ -102,13 +112,23 @@ def update_task(pulse_data):
         "started": run_obj.get("started"),
         "state": run_obj["state"],
     }
-    task_obj, _ = Task.objects.update_or_create(
+    task_obj, created = Task.objects.update_or_create(
         task_id=status["taskId"],
         run_id=run_id,
         defaults=defaults,
+    )
+    LOG.info(
+        "%s task %s run %d in pool %s/%s -> %s",
+        "created" if created else "updated",
+        status["taskId"],
+        run_id,
+        pool.pool_id,
+        pool.platform,
+        run_obj["state"],
     )
     if task_obj.created is None:
         # `created` field isn't available via pulse, so get it from Taskcluster
         queue_svc = taskcluster.Queue({"rootUrl": settings.TC_ROOT_URL})
         task = queue_svc.task(status["taskId"])
         Task.objects.filter(id=task_obj.id).update(created=task["created"])
+        LOG.info("task %s was created at %s", status["taskId"], task["created"])


### PR DESCRIPTION
If a task worker type did not match a fuzzing-tc pool, we would return early from the pool creation function, but continue to add
the task in the DB.

Fix this case, and add extra logging so cases like this are easier to debug in the future.

Also add a management command to add a task group manually in case existing tasks need to be added.