### PR TITLE
Publish testcase and crashdata files as attachments during Bugzilla bug publication

### DIFF
--- a/server/crashmanager/static/css/default.css
+++ b/server/crashmanager/static/css/default.css
@@ -45,7 +45,8 @@ a.fixedbug:active {
   height: 600px;
 }
 
-#id_crashdata_attach {
+#id_crashdata_attach,
+#id_testcase_content {
   height: 400px;
 }
 

--- a/server/frontend/src/api.js
+++ b/server/frontend/src/api.js
@@ -19,6 +19,9 @@ export const updateBucket = async ({ id, params, ...data }) =>
 export const retrieveCrash = async (id) =>
   (await mainAxios.get(`/crashmanager/rest/crashes/${id}/`)).data;
 
+export const retrieveCrashTestCase = async (id) =>
+  (await mainAxios.get(`/crashmanager/rest/crashes/${id}/download/`)).data;
+
 export const listCrashes = async (params) =>
   (await mainAxios.get("/crashmanager/rest/crashes/", { params })).data;
 

--- a/server/frontend/src/bugzilla_api.js
+++ b/server/frontend/src/bugzilla_api.js
@@ -28,3 +28,12 @@ export const fetchPossibleDuplicates = async ({ hostname, params, headers }) =>
 export const createBug = async ({ hostname, headers, ...data }) =>
   (await bugzillaAxios.post(`https://${hostname}/rest/bug`, data, { headers }))
     .data;
+
+export const createAttachment = async ({ hostname, id, headers, ...data }) =>
+  (
+    await bugzillaAxios.post(
+      `https://${hostname}/rest/bug/${id}/attachment`,
+      data,
+      { headers }
+    )
+  ).data;

--- a/server/frontend/src/components/Bugs/CrashDataSection.vue
+++ b/server/frontend/src/components/Bugs/CrashDataSection.vue
@@ -1,0 +1,81 @@
+<template>
+  <div>
+    <h3>Crash data</h3>
+    <div class="row">
+      <div class="form-group col-md-6">
+        <input
+          type="checkbox"
+          id="id_crashdata_skip"
+          name="crashdata_skip"
+          v-model="notAttachData"
+        />
+        <span>Do not attach crash data.</span>
+      </div>
+    </div>
+    <div v-if="!notAttachData">
+      <div class="alert alert-info" role="alert">
+        Crash data will be attached to the {{ mode }}.
+      </div>
+      <div class="row">
+        <div class="form-group col-md-12">
+          <label for="crashdata_attach">Content:</label>
+          <textarea
+            id="id_crashdata_attach"
+            class="form-control"
+            name="crashdata_attach"
+            type="text"
+            v-model="data"
+          ></textarea>
+        </div>
+      </div>
+    </div>
+    <hr />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    mode: {
+      type: String,
+      required: false,
+      default: "bug",
+    },
+    initialNotAttachData: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    initialData: {
+      type: String,
+      required: true,
+    },
+    pathPrefix: {
+      type: String,
+      required: false,
+      default: null,
+    },
+  },
+  data: () => ({
+    notAttachData: false,
+    data: "",
+  }),
+  async mounted() {
+    this.notAttachData = this.initialNotAttachData;
+    this.data = this.initialData;
+  },
+  watch: {
+    notAttachData: function () {
+      this.$emit("update-not-attach-data", this.notAttachData);
+    },
+    data: function () {
+      if (this.pathPrefix) {
+        this.data = this.data.replaceAll(this.pathPrefix, "");
+      }
+      this.$emit("update-data", this.data);
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/server/frontend/src/components/Bugs/PublicationForm.vue
+++ b/server/frontend/src/components/Bugs/PublicationForm.vue
@@ -496,9 +496,9 @@ export default {
     assignError: null,
     createdBugId: null,
     notAttachTest: false,
-    testCaseContent: null,
+    testCaseContent: "",
     notAttachData: false,
-    crashData: null,
+    crashData: "",
   }),
   async mounted() {
     this.entry = await api.retrieveCrash(this.entryId);

--- a/server/frontend/src/components/Bugs/TestCaseSection.vue
+++ b/server/frontend/src/components/Bugs/TestCaseSection.vue
@@ -1,0 +1,96 @@
+<template>
+  <div>
+    <h3>Testcase</h3>
+    <div class="row">
+      <div class="form-group col-md-6">
+        <input
+          type="checkbox"
+          id="id_testcase_skip"
+          name="testcase_skip"
+          v-model="notAttachTest"
+        />
+        <span>Do not attach a testcase (file {{ mode }} without test).</span>
+      </div>
+    </div>
+    <div v-if="!notAttachTest">
+      <div class="alert alert-info" role="alert">
+        Testcase will be attached to the bug.
+      </div>
+      <div class="row">
+        <div class="form-group col-md-6">
+          <label for="testcase_filename">Filename:</label>
+          <input
+            id="id_testcase_filename"
+            class="form-control"
+            name="testcase_filename"
+            type="text"
+            v-model="filename"
+          />
+        </div>
+      </div>
+      <div class="row" v-if="!entry.testcase_isbinary">
+        <div class="form-group col-md-12">
+          <label for="testcase_content">Content:</label>
+          <textarea
+            id="id_testcase_content"
+            class="form-control"
+            name="testcase_content"
+            type="text"
+            :readonly="content === 'Content loading...'"
+            v-model="content"
+          ></textarea>
+        </div>
+      </div>
+    </div>
+    <hr />
+  </div>
+</template>
+
+<script>
+import * as api from "../../api";
+
+export default {
+  props: {
+    mode: {
+      type: String,
+      required: false,
+      default: "bug",
+    },
+    initialNotAttachTest: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    entry: {
+      type: Object,
+      required: true,
+    },
+  },
+  data: () => ({
+    notAttachTest: false,
+    filename: "",
+    content: "Content loading...",
+  }),
+  async mounted() {
+    this.notAttachTest = this.initialNotAttachTest;
+    this.filename = this.entry.testcase.split(/[\\/]/).pop();
+    if (!this.entry.testcase_isbinary)
+      this.content = await api.retrieveCrashTestCase(this.entry.id);
+  },
+  watch: {
+    notAttachTest: function () {
+      this.$emit("update-not-attach-test", this.notAttachTest);
+    },
+    filename: function () {
+      if (this.filename) this.$emit("update-filename", this.filename);
+      // Prevent removing the whole section when the filename input is empty
+      else this.$emit("update-filename", " ");
+    },
+    content: function () {
+      this.$emit("update-content", this.content);
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/server/frontend/src/components/Bugs/TestCaseSection.vue
+++ b/server/frontend/src/components/Bugs/TestCaseSection.vue
@@ -14,7 +14,7 @@
     </div>
     <div v-if="!notAttachTest">
       <div class="alert alert-info" role="alert">
-        Testcase will be attached to the bug.
+        Testcase will be attached to the {{ mode }}.
       </div>
       <div class="row">
         <div class="form-group col-md-6">


### PR DESCRIPTION
Depends on #701 

References #695 