### PR TITLE
Create pools with database ID matching fuzzing-tc-config

### DIFF
--- a/server/taskmanager/tasks.py
+++ b/server/taskmanager/tasks.py
@@ -14,6 +14,7 @@ LOG = getLogger("taskmanager.tasks")
 def get_or_create_pool(worker_type):
     from .models import Pool
 
+    params = {}
     if worker_type in settings.TC_EXTRA_POOLS:
         platform = "linux"  # default .. change manually if wrong
         pool_id = worker_type
@@ -23,13 +24,16 @@ def get_or_create_pool(worker_type):
             return
         platform, pool_id = worker_type.split("-", 1)
         assert pool_id.startswith("pool")
+        try:
+            params["id"] = int(pool_id[4:])
+        except ValueError:
+            pass
+    params["pool_name"] = pool_id
 
     pool, created = Pool.objects.get_or_create(
         pool_id=pool_id,
         platform=platform,
-        defaults={
-            "pool_name": pool_id,
-        },
+        defaults=params,
     )
     if created:
         LOG.info("created new pool %d for %s/%s", pool.id, platform, pool_id)


### PR DESCRIPTION
The problem with this is any pools in `TC_EXTRA_POOLS` could steal the ID from a fuzzing pool and require manual intervention. This isn't a problem with our instance anymore, since we already have high IDs manually created.