### PR TITLE
Add support for overriding `.fuzzmanagerconf`

### DIFF
--- a/Reporter/Reporter.py
+++ b/Reporter/Reporter.py
@@ -114,7 +114,10 @@ class Reporter():
 
         # Now search for the global configuration file. If it exists, read its contents
         # and set all Collector settings that haven't been explicitely set by the user.
-        globalConfigFile = os.path.join(os.path.expanduser("~"), ".fuzzmanagerconf")
+        globalConfigFile = os.getenv(
+            "FM_CONFIG_PATH",
+            os.path.join(os.path.expanduser("~"), ".fuzzmanagerconf"),
+        )
         if os.path.exists(globalConfigFile):
             configInstance = ConfigurationFiles([globalConfigFile])
             globalConfig = configInstance.mainConfig


### PR DESCRIPTION
Use environment variable `FM_CONFIG_PATH`. This makes submitting data to a local test instance easier.