### PR TITLE
Fix bucket watch notifications

### DIFF
--- a/server/crashmanager/management/commands/triage_new_crash.py
+++ b/server/crashmanager/management/commands/triage_new_crash.py
@@ -1,0 +1,75 @@
+from collections import OrderedDict
+
+from django.conf import settings
+from django.core.management import BaseCommand
+
+from crashmanager.management.common import mgmt_lock_required
+from crashmanager.models import CrashEntry, Bucket
+
+
+# This is a per-worker global cache mapping short descriptions of
+# crashes to a list of bucket candidates to try first.
+#
+# although this cache looks pointless within this command,
+# the command is called in a loop from triage_new_crashes.py
+# and may be called multiple times in one process by celery
+TRIAGE_CACHE = OrderedDict()
+
+
+class Command(BaseCommand):
+    help = ("Triage a crash entry into an existing bucket.")
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "id",
+            type=int,
+            help="Crash ID",
+        )
+
+    @mgmt_lock_required
+    def handle(self, *args, **options):
+        entry = CrashEntry.objects.get(pk=options["id"])
+        crashInfo = entry.getCrashInfo(attachTestcase=True)
+
+        cacheHit = False
+
+        triage_cache_hint = TRIAGE_CACHE.get(entry.shortSignature)
+
+        if triage_cache_hint:
+            buckets = Bucket.objects.filter(pk__in=triage_cache_hint)
+            for bucket in buckets:
+                signature = bucket.getSignature()
+                if signature.matches(crashInfo):
+                    entry.bucket = bucket
+                    print("Cache hit")
+                    cacheHit = True
+                    break
+
+        if not cacheHit:
+            buckets = Bucket.objects.all()
+
+            for bucket in buckets:
+                signature = bucket.getSignature()
+                if signature.matches(crashInfo):
+                    entry.bucket = bucket
+
+                    cacheList = [bucket.pk]
+                    if triage_cache_hint:
+                        cacheList = TRIAGE_CACHE[entry.shortSignature]
+
+                        # We delete the current entry and add it again to ensure
+                        # that our dictionary remains ordered by the time of last
+                        # use. We can then just pop the first element if the cache
+                        # grows too large, evicting the least used item.
+                        del TRIAGE_CACHE[entry.shortSignature]
+                        cacheList.append(bucket.pk)
+
+                    TRIAGE_CACHE[entry.shortSignature] = cacheList
+
+                    if len(TRIAGE_CACHE) > getattr(settings, 'CELERY_TRIAGE_MEMCACHE_ENTRIES', 100):
+                        TRIAGE_CACHE.popitem(last=False)
+
+                    break
+
+        entry.triagedOnce = True
+        entry.save()

--- a/server/crashmanager/tasks.py
+++ b/server/crashmanager/tasks.py
@@ -1,61 +1,9 @@
-from collections import OrderedDict
-
-from django.conf import settings
+from django.core.management import call_command
 
 from celeryconf import app
 from . import cron  # noqa ensure cron tasks get registered
 
-# This is a per-worker global cache mapping short descriptions of
-# crashes to a list of bucket candidates to try first.
-triage_cache = OrderedDict()
-
 
 @app.task(ignore_result=True)
 def triage_new_crash(pk):
-    from .models import CrashEntry, Bucket
-    entry = CrashEntry.objects.get(pk=pk)
-    crashInfo = entry.getCrashInfo(attachTestcase=True)
-
-    cacheHit = False
-
-    triage_cache_hint = triage_cache.get(entry.shortSignature)
-
-    if triage_cache_hint:
-        buckets = Bucket.objects.filter(pk__in=triage_cache_hint)
-        for bucket in buckets:
-            signature = bucket.getSignature()
-            if signature.matches(crashInfo):
-                entry.bucket = bucket
-                print("Cache hit")
-                cacheHit = True
-                break
-
-    if not cacheHit:
-        buckets = Bucket.objects.all()
-
-        for bucket in buckets:
-            signature = bucket.getSignature()
-            if signature.matches(crashInfo):
-                entry.bucket = bucket
-
-                cacheList = [bucket.pk]
-                if triage_cache_hint:
-                    cacheList = triage_cache[entry.shortSignature]
-
-                    # We delete the current entry and add it again to ensure
-                    # that our dictionary remains ordered by the time of last
-                    # use. We can then just pop the first element if the cache
-                    # grows to large, evicting the least used item.
-                    del triage_cache[entry.shortSignature]
-                    cacheList.append(bucket.pk)
-
-                triage_cache[entry.shortSignature] = cacheList
-
-                # TODO: Make this length configurable
-                if len(triage_cache) > getattr(settings, 'CELERY_TRIAGE_MEMCACHE_ENTRIES', 100):
-                    triage_cache.popitem(last=False)
-
-                break
-
-    entry.triagedOnce = True
-    entry.save()
+    call_command('triage_new_crash', pk)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -10,7 +10,7 @@ celery>=4.1.1,<4.3
 certifi>=2018.4.16
 chardet>=3.0.4,<3.1
 configparser>=3.5.0,<3.6; python_version == '2.7'
-coverage==4.5.2
+coverage==5.5
 Django>=1.11.20,<3
 django-chartjs==1.3
 django-crispy-forms==1.11.2

--- a/server/requirements3.0.txt
+++ b/server/requirements3.0.txt
@@ -10,7 +10,7 @@ celery>=4.1.1,<4.3
 certifi>=2018.4.16
 chardet>=3.0.4,<3.1
 configparser>=3.5.0,<3.6; python_version == '2.7'
-coverage==4.5.2
+coverage==5.5
 Django>=3.0,<3.1
 django-chartjs==1.3
 django-crispy-forms==1.11.2


### PR DESCRIPTION
Merge the two triage functions (celery/cron) into one, and generate watch notification in `CrashEntry.save` so it is generated regardless of how the crash is assigned to the bucket.