### PR TITLE
[crashmanager] Use testcase filename if defined in template

### DIFF
--- a/server/frontend/src/components/Bugs/PublicationForm.vue
+++ b/server/frontend/src/components/Bugs/PublicationForm.vue
@@ -402,6 +402,7 @@
           :initial-not-attach-test="notAttachTest"
           v-on:update-not-attach-test="notAttachTest = $event"
           :entry="entry"
+          :template="template"
           v-on:update-filename="entry.testcase = $event"
           v-on:update-content="testCaseContent = $event"
         />

--- a/server/frontend/src/components/Bugs/TestCaseSection.vue
+++ b/server/frontend/src/components/Bugs/TestCaseSection.vue
@@ -65,6 +65,10 @@ export default {
       type: Object,
       required: true,
     },
+    template: {
+      type: Object,
+      required: true,
+    },
   },
   data: () => ({
     notAttachTest: false,
@@ -73,7 +77,9 @@ export default {
   }),
   async mounted() {
     this.notAttachTest = this.initialNotAttachTest;
-    this.filename = this.entry.testcase.split(/[\\/]/).pop();
+    this.filename = this.template
+      ? this.template.testcase_filename
+      : this.entry.testcase.split(/[\\/]/).pop();
     if (!this.entry.testcase_isbinary)
       this.content = await api.retrieveCrashTestCase(this.entry.id);
   },


### PR DESCRIPTION
If the template defines a filename to use for the testcase, use that.  If not, default to the crash entry filename.