### PR TITLE
Combine wordbreak and responsive tables

### DIFF
--- a/server/crashmanager/static/css/default.css
+++ b/server/crashmanager/static/css/default.css
@@ -60,39 +60,17 @@ a.fixedbug:active {
 }
 
 /* database tables */
-
 .table-db {
-  white-space: nowrap
+  width: 100%;
+  word-break: normal;
 }
 
 .table-db th {
   background: #eee;
 }
 
-.table tbody td {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-/* limit display size of short signature column */
-
 .short-sig {
-  max-width: 68ch;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-@media only screen and (min-width : 992px) {
-  .short-sig {
-      max-width: 68ch;
-  }
-}
-
-@media only screen and (min-width : 1200px) {
-  .short-sig {
-      max-width: 90ch;
-  }
+  word-break: normal;
 }
 
 /* sticky footer */


### PR DESCRIPTION
Allows table-layout `auto` to decide when to apply horizontal scroll or word break.

![image](https://user-images.githubusercontent.com/1735164/140398898-75f32861-2c9c-4673-8df4-4aa66f7b70b8.png)
![image](https://user-images.githubusercontent.com/1735164/140398967-cee1db94-9659-46eb-8cb3-bdfd885afa93.png)
