### PR TITLE
Crash list UI changes

### DIFF
--- a/server/crashmanager/static/css/default.css
+++ b/server/crashmanager/static/css/default.css
@@ -81,6 +81,13 @@ a.fixedbug:active {
   white-space: normal;
 }
 
+.two-line-limit {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
 /* sticky footer */
 
 .footer {

--- a/server/crashmanager/static/css/default.css
+++ b/server/crashmanager/static/css/default.css
@@ -62,15 +62,23 @@ a.fixedbug:active {
 /* database tables */
 .table-db {
   width: 100%;
-  word-break: normal;
 }
 
 .table-db th {
   background: #eee;
 }
 
-.short-sig {
-  word-break: normal;
+.wrap-none {
+  white-space: nowrap;
+}
+
+.wrap-normal {
+  white-space: normal;
+}
+
+.wrap-anywhere {
+  word-break: break-all;
+  white-space: normal;
 }
 
 /* sticky footer */

--- a/server/crashmanager/templates/crashes/view.html
+++ b/server/crashmanager/templates/crashes/view.html
@@ -42,7 +42,7 @@
             </td></tr>
             <tr><td>Created</td><td>{{ entry.created|date:"r" }}</td></tr>
             <tr><td>Client</td><td>{{ entry.client.name|escape }}</td></tr>
-            <tr><td>Short Signature</td><td>{{ entry.shortSignature|escape }}</td></tr>
+            <tr><td>Short Signature</td><td class="wrap-anywhere">{{ entry.shortSignature|escape }}</td></tr>
             <tr><td>Product</td><td>{{ entry.product.name }}</td></tr>
             <tr><td>Version</td><td>{{ entry.product.version }}</td></tr>
             <tr><td>Platform</td><td>{{ entry.platform.name }}</td></tr>

--- a/server/frontend/src/components/Crashes/List.vue
+++ b/server/frontend/src/components/Crashes/List.vue
@@ -209,7 +209,7 @@
                   sortKeys.includes('-testcase__quality'),
               }"
             >
-              Test Status
+              Test Info
             </th>
             <th
               v-on:click.exact="sortBy('product__name')"

--- a/server/frontend/src/components/Crashes/List.vue
+++ b/server/frontend/src/components/Crashes/List.vue
@@ -146,7 +146,9 @@
       </div>
     </div>
     <div class="table-responsive">
-      <table class="table table-condensed table-hover table-bordered table-db">
+      <table
+        class="table table-condensed table-hover table-bordered table-db wrap-none"
+      >
         <thead>
           <tr>
             <th

--- a/server/frontend/src/components/Crashes/Row.vue
+++ b/server/frontend/src/components/Crashes/Row.vue
@@ -30,7 +30,9 @@
         class="bi bi-search dimgray"
       ></a>
     </td>
-    <td class="wrap-anywhere">{{ crash.shortSignature }}</td>
+    <td class="wrap-anywhere">
+      <span class="two-line-limit">{{ crash.shortSignature }}</span>
+    </td>
     <td>{{ crash.crashAddress }}</td>
     <td v-if="crash.testcase">
       <a
@@ -52,12 +54,14 @@
       >
     </td>
     <td class="wrap-anywhere">
-      <a
-        title="Add to search"
-        class="add-filter"
-        v-on:click="addFilter('product__version', crash.product_version)"
-        >{{ crash.product_version }}</a
-      >
+      <span class="two-line-limit">
+        <a
+          title="Add to search"
+          class="add-filter"
+          v-on:click="addFilter('product__version', crash.product_version)"
+          >{{ crash.product_version }}</a
+        >
+      </span>
     </td>
     <td>
       <a

--- a/server/frontend/src/components/Crashes/Row.vue
+++ b/server/frontend/src/components/Crashes/Row.vue
@@ -3,7 +3,7 @@
     <td>
       <a :href="crash.view_url">{{ crash.id }}</a>
     </td>
-    <td>{{ crash.created | formatDate }}</td>
+    <td class="wrap-normal">{{ crash.created | formatDate }}</td>
     <td v-if="crash.bucket">
       <a :href="crash.sig_view_url">{{ crash.bucket }} </a>
     </td>
@@ -30,7 +30,7 @@
         class="bi bi-search dimgray"
       ></a>
     </td>
-    <td class="short-sig">{{ crash.shortSignature }}</td>
+    <td class="wrap-anywhere">{{ crash.shortSignature }}</td>
     <td>{{ crash.crashAddress }}</td>
     <td v-if="crash.testcase">
       <a
@@ -51,7 +51,7 @@
         >{{ crash.product }}</a
       >
     </td>
-    <td>
+    <td class="wrap-anywhere">
       <a
         title="Add to search"
         class="add-filter"

--- a/server/frontend/src/components/Crashes/Row.vue
+++ b/server/frontend/src/components/Crashes/Row.vue
@@ -39,8 +39,8 @@
         v-on:click="addFilter('testcase__quality', crash.testcase_quality)"
         >Q{{ crash.testcase_quality }}</a
       >
-      {{ crash.testcase_size }}
-      <span v-if="crash.testcase_isbinary">(binary)</span>
+      {{ crash.testcase_size | formatSize }}
+      <i class="bi bi-file-binary" v-if="crash.testcase_isbinary"></i>
     </td>
     <td v-else>No test</td>
     <td>
@@ -116,7 +116,7 @@
 </template>
 
 <script>
-import { formatClientTimestamp } from "../../helpers";
+import { formatClientTimestamp, formatSizeFriendly } from "../../helpers";
 
 export default {
   props: {
@@ -127,6 +127,7 @@ export default {
   },
   filters: {
     formatDate: formatClientTimestamp,
+    formatSize: formatSizeFriendly,
   },
   methods: {
     addFilter(key, value) {

--- a/server/frontend/src/helpers.js
+++ b/server/frontend/src/helpers.js
@@ -38,6 +38,14 @@ export const errorParser = (error) => {
 
 export const E_SERVER_ERROR = "Error while communicating with the server.";
 
+export const formatSizeFriendly = (sz) => {
+  if (sz >= 1024 * 1024 * 1024)
+    return Math.round(sz / 1024 / 1024 / 1024) + "G";
+  if (sz >= 1024 * 1024) return Math.round(sz / 1024 / 1024) + "M";
+  if (sz >= 1024) return Math.round(sz / 1024) + "K";
+  return sz + "";
+};
+
 export const formatClientTimestamp = (datetime) => {
   return new Intl.DateTimeFormat(undefined, {
     year: "numeric",


### PR DESCRIPTION
There are three changes here:
- fix line-wrapping (no fields wrap except date, short-signature, and version).
- make testcase column more concise by replacing `(binary)` with an icon, and making size human-readable.
- truncate short-signature and version after two lines.

N.B. #808 also changes the date-time format, not shown here.

Before:
![image](https://user-images.githubusercontent.com/4673461/140776605-df89bf2c-855e-4f02-a199-a732778b83aa.png)

After:
![image](https://user-images.githubusercontent.com/4673461/140771424-4b464977-c836-45ea-8823-d0aff0d0e017.png)
