### PR TITLE
Handle the case where testcase_ext is given with no testcase.

### DIFF
--- a/server/crashmanager/serializers.py
+++ b/server/crashmanager/serializers.py
@@ -114,6 +114,7 @@ class CrashEntrySerializer(serializers.ModelSerializer):
             attrs['testcase'] = dbobj
         else:
             attrs['testcase'] = None
+            attrs.pop('testcase_ext', None)
 
         try:
             # Create our CrashEntry instance

--- a/server/crashmanager/tests/test_crashes_rest.py
+++ b/server/crashmanager/tests/test_crashes_rest.py
@@ -291,6 +291,7 @@ def test_rest_crashes_list_query(api_client, cm, user, expected, toolfilter):
         'os': 'linux',
         'client': 'client1',
         'tool': 'tool1',
+        'testcase_ext': 'js',
     },
     # crash reporting works with empty fields where allowed
     {


### PR DESCRIPTION
This causes the server to traceback when it should just ignore it.