### PR TITLE
Repack wheel to exclude 'extra_requires'

### DIFF
--- a/repack_wheel.sh
+++ b/repack_wheel.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e -x
+
+#
+# Remove 'extra_requires' from the wheel
+#
+# The 'extras' are only useful with the full source distribution.
+#
+
+WORK="$(mktemp -d -t fm-twine-repack-XXXXXX)"
+wheel unpack -d "$WORK" dist/FuzzManager-*.whl
+grep -Ev "^(Provides-Extra: .*|Requires-Dist: .* ; extra == '.*')$" "$WORK"/FuzzManager-*/FuzzManager-*.dist-info/METADATA > "$WORK"/METADATA.new
+mv "$WORK"/METADATA.new "$WORK"/FuzzManager-*/FuzzManager-*.dist-info/METADATA
+wheel pack -d dist "$WORK"/FuzzManager-*
+rm -rf "$WORK"

--- a/tox.ini
+++ b/tox.ini
@@ -40,9 +40,12 @@ commands =
 skip_install = true
 deps =
     twine
+    wheel
 commands =
     python setup.py sdist bdist_wheel
+    bash repack_wheel.sh
     twine upload --skip-existing dist/*
+whitelist_externals = bash
 
 [flake8]
 # This ignore section is for running flake8 standalone vs through pytest


### PR DESCRIPTION
fuzzing-decision (used by taskmanager) uses a direct url reference (allowed by [PEP 508](https://www.python.org/dev/peps/pep-0508/)). But PyPI cannot accept direct url references.

We don't need any of the extras anyways for the wheel (Collector/FTB only).

See https://github.com/pypa/twine/issues/430