### PR TITLE
Improve memory usage for bucket edit reassignment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,12 @@ repos:
     hooks:
       - id: yesqa
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.32.0
     hooks:
       - id: pyupgrade
         args: ['--py37-plus']
   - repo: https://github.com/ambv/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8


### PR DESCRIPTION
Instead of chunking the entire query, fetch all IDs and chunk those.

Otherwise `LIMIT`/`OFFSET` chunking can degrade SQL performance enough to cause timeout.