### PR TITLE
Ignore coverage reports containing IGNORE_MERGE

### DIFF
--- a/server/covmanager/cron.py
+++ b/server/covmanager/cron.py
@@ -33,9 +33,11 @@ def create_weekly_report_mc(revision):
     repository = Repository.objects.get(name="mozilla-central")
     client = Client.objects.get_or_create(name="Server")[0]
 
-    collections = Collection.objects.filter(
-        Q(revision=revision) | Q(revision=short_revision)
-    ).filter(repository=repository, coverage__isnull=False)
+    collections = (
+        Collection.objects.filter(Q(revision=revision) | Q(revision=short_revision))
+        .filter(repository=repository, coverage__isnull=False)
+        .exclude(description__contains="IGNORE_MERGE")
+    )
 
     last_monday = collections.first().created + relativedelta(weekday=MO(-1))
 


### PR DESCRIPTION
Allows coverage reports containing a description with `IGNORE_MERGE` to be excluding from the weekly merge job.