### PR TITLE
Show when signature deletion will affect hidden crashes.

### DIFF
--- a/server/crashmanager/templates/signatures/remove.html
+++ b/server/crashmanager/templates/signatures/remove.html
@@ -2,23 +2,33 @@
 
 {% block body_content %}
 <div class="panel panel-default">
-    <div class="panel-heading"><i class="bi bi-tag-fill"></i> Remove Signature</div>
-	<div class="panel-body">
-		{% if error_message %}<p><strong>{{ error_message }}</strong></p>{% endif %}
-		<form action="{% url 'crashmanager:sigdel' bucket.pk %}" method="post">
-		{% csrf_token %}
-		<div class="alert alert-danger" role="alert">Are you sure that you want to delete this signature?</div>
-		<div class="field">
-			<strong>Description:</strong> {{ bucket.shortDescription|escape }}
-		</div>
+  <div class="panel-heading"><i class="bi bi-tag-fill"></i> Remove Signature</div>
+  <div class="panel-body">
+    {% if error_message %}<p><strong>{{ error_message }}</strong></p>{% endif %}
+    <form action="{% url 'crashmanager:sigdel' bucket.pk %}" method="post">
+      {% csrf_token %}
+      <div class="alert alert-danger" role="alert">Are you sure that you want to delete this signature?</div>
+      <div class="field">
+        <strong>Description:</strong> {{ bucket.shortDescription|escape }}
+      </div>
 
-		<div class="field">
-		    <input type="checkbox" id="id_delentries" name="delentries"/>
-		    <label for="id_delentries">Also delete all {{ bucket.size }} entries with this bucket</label>
-		</div>
-		<input type="submit" value="Delete" class="btn btn-danger"/>
-		<input type="button" value="Cancel" class="btn btn-default" onClick="javascript:history.go(-1)"/>
-		</form>
-	</div>
+      <div class="field">
+        {% if out_of_filter > 0 or in_filter > 0 %}
+        <input type="checkbox" id="id_delentries" name="delentries"/>
+        <label for="id_delentries">
+        {% if out_of_filter > 0 %}
+          Also delete all crash entries with this bucket: {{ in_filter }} in tool filter, {{ out_of_filter }} in other tools ({{ other_tools }}).
+        {% else %}
+          Also delete all crash entries with this bucket: {{ in_filter }} in tool filter (none in other tools).
+        {% endif %}
+        </label>
+        {% else %}
+        Bucket contains no crash entries.
+        {% endif %}
+      </div>
+      <input type="submit" value="Delete" class="btn btn-danger"/>
+      <input type="button" value="Cancel" class="btn btn-default" onClick="javascript:history.go(-1)"/>
+    </form>
+  </div>
 </div>
 {% endblock body_content %}

--- a/server/taskmanager/tests/fixtures/pool1/pool1.yml
+++ b/server/taskmanager/tests/fixtures/pool1/pool1.yml
@@ -13,6 +13,7 @@ container: MozillaSecurity/fuzzer:latest
 minimum_memory_per_core: 1g
 imageset: generic-worker-A
 cpu: x64
+gpu: false
 platform: linux
 preprocess: ""
 macros:


### PR DESCRIPTION
Previously we only showed the total number of crashes, which could include crashes not in tool filter.

Now we will separately show the in/out of tool filter totals, and a list of tools outside of filter that have crashes in the bucket.

This changes permissions slightly: restricted users are not allowed to delete signatures anymore, even if all crashes are in a visible signature.