### PR TITLE
[CovReporter] grcov output always uses forward-slash for paths

### DIFF
--- a/CovReporter/CovReporter.py
+++ b/CovReporter/CovReporter.py
@@ -165,7 +165,7 @@ class CovReporter(Reporter):
 
                 # Split the filename into path parts and file part
                 name = source_file["name"]
-                name_parts = name.split(os.sep)
+                name_parts = name.split("/")
                 path_parts = name_parts[:-1]
                 file_part = name_parts[-1]
 


### PR DESCRIPTION
See https://github.com/mozilla/grcov/blame/33f3611588e5cebe30c98d0c7d2fa36dcf94664e/src/path_rewriting.rs#L279