### PR TITLE
Add middleware to add username as a response header.

### DIFF
--- a/server/server/middleware.py
+++ b/server/server/middleware.py
@@ -95,3 +95,14 @@ class CheckAppPermissionsMiddleware:
             return HttpResponseForbidden()
 
         return None
+
+
+class AddXUsernameMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if request.user.is_authenticated:
+            response["X-Username"] = request.user.username
+        return response

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -73,6 +73,7 @@ MIDDLEWARE = (
     "django.contrib.messages.middleware.MessageMiddleware",
     "server.middleware.ExceptionLoggingMiddleware",
     "server.middleware.CheckAppPermissionsMiddleware",
+    "server.middleware.AddXUsernameMiddleware",
     # 'livesync.core.middleware.DjangoLiveSyncMiddleware',
     "whitenoise.middleware.WhiteNoiseMiddleware",
 )


### PR DESCRIPTION
This allows using it in access logs by gunicorn or nginx.