### PR TITLE
WIP: Add 'created' field to reportsummary and expose in UI (#939)

### DIFF
--- a/server/covmanager/tasks.py
+++ b/server/covmanager/tasks.py
@@ -125,6 +125,7 @@ def calculate_report_summary(pk):
         elif not data:
             # This is the root
             data = coverage
+            data["created"] = collection.created
         else:
             summary.cached_result = json.dumps(
                 {"error": "There are multiple root reports configured."}

--- a/server/covmanager/templates/reportconfigurations/summary.html
+++ b/server/covmanager/templates/reportconfigurations/summary.html
@@ -24,8 +24,8 @@
 
 {% block body_content %}
 <div id="main" class="panel panel-default">
-  <div class="panel-heading"><i class="bi bi-file-bar-graph"></i> Report Summary</div>
   <template v-if="loading">
+    <div class="panel-heading"><i class="bi bi-file-bar-graph"></i> Report Summary</div>
     <div class="loader">
     </div>
     <template v-if="loading_incomplete">
@@ -35,7 +35,8 @@
     </template>
   </template>
   <template v-else>
-  <div class="panel-body">
+    <div class="panel-heading"><i class="bi bi-file-bar-graph"></i> Report Summary - <span v-text="chart.data.created"></span></div>
+    <div class="panel-body">
     <button @click="refresh()" class="btn btn-default">Refresh this Report Summary</button>
     <button @click="textual()" class="btn btn-default">View Textual Report</button>
   </div>
@@ -81,7 +82,8 @@ let covmanager = new Vue({
   },
   watch: {
     'chart.data': function() {
-      this.draw()
+      this.draw();
+      document.title = '{{ collectionid }} - Summary - ' + chart.data.created;
     },
     'chart.level': function() {
       this.draw()


### PR DESCRIPTION
This only adds a _created_ field during cache generation, which
wouldn't make it work for old, cached reports.
It also involved quite a bit of vue hackery, due to the data
not being available during django page render.
Maybe the model ought to change to take not only a `collectionid`
but also a `collection.created`?
This is also WIP because I'm literally dumping the Python `created`
attribute into the JSON and reading it out in JS. There is no explicit
serialization/parsing of the date and I'm not sure what format
is going to be used. Heh.
