### PR TITLE
Fix ubsan error parsing when no stack is present

### DIFF
--- a/FTB/Signatures/CrashInfo.py
+++ b/FTB/Signatures/CrashInfo.py
@@ -1016,12 +1016,6 @@ class UBSanCrashInfo(CrashInfo):
             self.backtrace.append(CrashInfo.sanitizeStackFrame(component))
             expectedIndex += 1
 
-        if not self.backtrace and ubsanPatternSeen:
-            # We've seen the crash address but no frames, so this is likely
-            # a crash on the heap with no symbols available. Add one artificial
-            # frame so it doesn't show up as "No crash detected"
-            self.backtrace.append("??")
-
     def createShortSignature(self):
         """
         @rtype: String

--- a/FTB/Signatures/tests/fixtures/trace_ubsan_div_by_zero_no_trace.txt
+++ b/FTB/Signatures/tests/fixtures/trace_ubsan_div_by_zero_no_trace.txt
@@ -1,0 +1,1 @@
+src/opus_demo.c:870:40: runtime error: division by zero

--- a/FTB/Signatures/tests/fixtures/trace_ubsan_generic_crash_no_trace.txt
+++ b/FTB/Signatures/tests/fixtures/trace_ubsan_generic_crash_no_trace.txt
@@ -1,0 +1,5 @@
+==8555==ERROR: UndefinedBehaviorSanitizer: SEGV on unknown address 0x000000004141 (pc 0x7f070b805037 bp 0x7f06626006b0 sp 0x7f0662600680 T28456)
+==8555==The signal is caused by a READ memory access.
+==8555==Hint: address points to the zero page.
+UndefinedBehaviorSanitizer can not provide additional info.
+==8555==ABORTING

--- a/FTB/Signatures/tests/test_CrashInfo.py
+++ b/FTB/Signatures/tests/test_CrashInfo.py
@@ -2304,6 +2304,24 @@ def test_UBSanParserTestCrash4():
     assert crashInfo.registers["sp"] == 0x7F0662600680
 
 
+def test_UBSanParserTestCrash5():
+    config = ProgramConfiguration("test", "x86-64", "linux")
+    crashInfo = CrashInfo.fromRawCrashData(
+        [],
+        [],
+        config,
+        (FIXTURE_PATH / "trace_ubsan_div_by_zero_no_trace.txt")
+        .read_text()
+        .splitlines(),
+    )
+    assert crashInfo.createShortSignature() == (
+        "UndefinedBehaviorSanitizer: src/opus_demo.c:870:40: "
+        "runtime error: division by zero"
+    )
+    assert not crashInfo.backtrace
+    assert crashInfo.crashAddress is None
+
+
 def test_RustParserTests1():
     """test RUST_BACKTRACE=1 is parsed correctly"""
     config = ProgramConfiguration("test", "x86-64", "linux")

--- a/FTB/Signatures/tests/test_CrashInfo.py
+++ b/FTB/Signatures/tests/test_CrashInfo.py
@@ -2322,6 +2322,24 @@ def test_UBSanParserTestCrash5():
     assert crashInfo.crashAddress is None
 
 
+def test_UBSanParserTestCrash6():
+    config = ProgramConfiguration("test", "x86-64", "linux")
+    crashInfo = CrashInfo.fromRawCrashData(
+        [],
+        [],
+        config,
+        (FIXTURE_PATH / "trace_ubsan_generic_crash_no_trace.txt")
+        .read_text()
+        .splitlines(),
+    )
+    assert crashInfo.createShortSignature() == ("[@ ??]")
+    assert not crashInfo.backtrace
+    assert crashInfo.crashAddress == 0x000000004141
+    assert crashInfo.registers["pc"] == 0x7F070B805037
+    assert crashInfo.registers["bp"] == 0x7F06626006B0
+    assert crashInfo.registers["sp"] == 0x7F0662600680
+
+
 def test_RustParserTests1():
     """test RUST_BACKTRACE=1 is parsed correctly"""
     config = ProgramConfiguration("test", "x86-64", "linux")


### PR DESCRIPTION
We were previously creating a dummy stack to avoid "No crash detected" for a SEGV without a stack, but this parser isn't used for that case anyways, and it breaks bucketing with `stackSize` symptoms.

Fixes #946 