### PR TITLE
Update Celery commands in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     image: mozillasecurity/fuzzmanager:compose
     pull_policy: never
 
-    command: celery -A celeryconf -l info beat
+    command: celery -A celeryconf beat -l info
 
     depends_on:
       - backend
@@ -38,7 +38,7 @@ services:
     image: mozillasecurity/fuzzmanager:compose
     pull_policy: never
 
-    command: celery -A celeryconf -l info -c 4 -n cron@%h -Q cron worker
+    command: celery -A celeryconf worker -l info -c 4 -n cron@%h -Q cron
 
     depends_on:
       - backend
@@ -54,7 +54,7 @@ services:
     image: mozillasecurity/fuzzmanager:compose
     pull_policy: never
 
-    command: celery -A celeryconf -l info -n worker@%h -Q celery worker
+    command: celery -A celeryconf worker -l info -n worker@%h -Q celery
 
     depends_on:
       - backend


### PR DESCRIPTION
Updating the Celery commands in the docker-compose.yml file for celery version 5.3.5.

Changes:
- For the "beat" service, the command has been updated to `celery -A celeryconf beat -l info`.
- For the "cron worker" service, the command has been updated to `celery -A celeryconf worker -l info -c 4 -n cron@%h -Q cron`.
- For the "celery worker" service, the command has been updated to`celery -A celeryconf worker -l info -n worker@%h -Q celery`.