### PR TITLE
Allow setting an alternative root by tag for coverage graph

### DIFF
--- a/server/covmanager/templates/collections/report.html
+++ b/server/covmanager/templates/collections/report.html
@@ -45,7 +45,7 @@
         <td>!{ report.description }!</td>
         <td>!{ report.data_created | formatDate }!</td>
         <td>
-          <button @click.stop="summary(report.coverage)" class="btn btn-default">View Report Summary</button>
+          <button @click.stop="summary(report.coverage, report.tag)" class="btn btn-default">View Report Summary</button>
           <button @click.stop="browse(report.coverage)" class="btn btn-default">Browse</button>
           <button @click.stop="publish(report)" v-if="unrestricted" class="btn btn-default">!{ report.publish_text }!</button>
           <button @click.stop="promote(report)" v-if="unrestricted" class="btn btn-default">!{ report.promote_text }!</button>
@@ -224,8 +224,11 @@ let covmanager = new Vue({
     browse: function(id) {
       window.open(`../collections/${id}/browse/`, '_blank').focus()
     },
-    summary: function(id) {
-      window.open(`../collections/${id}/summary/`, '_blank').focus()
+    summary: function(id, tag) {
+      if (tag) {
+        tag = `#root=${tag}`
+      }
+      window.open(`../collections/${id}/summary/${tag}`, '_blank').focus()
     },
     report_click_handler: function(id) {
       var self = this

--- a/server/covmanager/templates/reportconfigurations/summary.html
+++ b/server/covmanager/templates/reportconfigurations/summary.html
@@ -164,6 +164,17 @@ let covmanager = new Vue({
       let data = this.chart.data
       if (!data) return;
 
+      // Allows to set the root to one of the original root's children
+      let alt_root = pmanager.get_value('root', '')
+      if (alt_root && data.name != alt_root) {
+        for (x in data.children) {
+          if (data.children[x].name == alt_root) {
+            data = data.children[x];
+            break;
+          }
+        }
+      }
+
       let svg = d3.select("svg")
       let width = +svg.attr("width")
       let height = +svg.attr("height")


### PR DESCRIPTION
This allows the graph to be adjusted by a new hash parameter "root" that looks for the specified name in the data set as a direct child of the original root (this does not support recursive lookups, but it is also unlikely that this would be needed).

Assuming that the report tag is the same as the report configuration name, this can then be used to automatically display IPC graphs correctly.