### PR TITLE
update mysql image name in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
 
   database:
     container_name: fuzzmanager-db
-    image: mysql:8
+    image: mysql:8.3.0
     command: --default-authentication-plugin=mysql_native_password
 
     environment:


### PR DESCRIPTION
Updating used mysql image name in the docker-compose.yml file.
Currently, the image name has only the leftmost number defined, which defaults to the highest version under that number. Unfortunately, it seems that after version tag 8.4.0, database doesn't build correctly. Proposed change is to specify the number of the apparently last working version, which is 8.3.0.

Changes:
- changed mysql image name from mysql:8 to mysql:8.3.0.