### PR TITLE
Exclude IPC from general weekly coverage reports.

### DIFF
--- a/server/covmanager/cron.py
+++ b/server/covmanager/cron.py
@@ -41,6 +41,8 @@ def create_weekly_report_mc(revision, ipc_only=False):
 
     if ipc_only:
         collections = collections.filter(description__contains="IPC")
+    else:
+        collections = collections.exclude(description__contains="IPC")
 
     last_monday = collections.first().created + relativedelta(weekday=MO(-1))
 

--- a/server/taskmanager/tests/fixtures/pool1/pool1.yml
+++ b/server/taskmanager/tests/fixtures/pool1/pool1.yml
@@ -22,3 +22,4 @@ macros:
   ENVVAR2: 789abc
 run_as_admin: false
 nested_virtualization: false
+worker: generic


### PR DESCRIPTION
IPC and non-IPC builds collect coverage via incompatible methods. Until we figure out how to make them mergeable, we should separate them so that IPC reports don't alter which lines the general report considers coverable.