### PR TITLE
Use the global latest entry when creating a bucket watch

### DIFF
--- a/server/crashmanager/serializers.py
+++ b/server/crashmanager/serializers.py
@@ -188,7 +188,6 @@ class BucketSerializer(serializers.ModelSerializer):
     # size and best_quality are annotations, so must be set manually
     size = serializers.IntegerField(write_only=True, required=False)
     best_entry = serializers.IntegerField(write_only=True, required=False)
-    latest_entry = serializers.IntegerField(write_only=True, required=False)
     best_quality = serializers.IntegerField(write_only=True, required=False)
     bug_provider = serializers.PrimaryKeyRelatedField(
         write_only=True,
@@ -213,7 +212,6 @@ class BucketSerializer(serializers.ModelSerializer):
             "signature",
             "size",
             "has_optimization",
-            "latest_entry",
             "reassign_in_progress",
         )
         ordering = ["-id"]
@@ -229,7 +227,6 @@ class BucketSerializer(serializers.ModelSerializer):
         serialized = super().to_representation(obj)
         serialized["size"] = obj.size
         serialized["best_entry"] = getattr(obj, "best_entry", None)
-        serialized["latest_entry"] = getattr(obj, "latest_entry", None)
         serialized["best_quality"] = obj.quality
         serialized["has_optimization"] = bool(obj.optimizedSignature)
         return serialized

--- a/server/crashmanager/templates/signatures/view.html
+++ b/server/crashmanager/templates/signatures/view.html
@@ -8,6 +8,7 @@
   :activity-range="{{ activity_range }}"
   :bucket="{{ bucket }}"
   :best-entry-size="{{ best_entry_size }}"
+  :latest-entry="{{ latest_entry_global }}"
   :providers="{{ providers }}"
   {% if best_entry %}
   best-view-url="{% url 'crashmanager:crashview' best_entry %}"

--- a/server/crashmanager/tests/test_signatures_rest.py
+++ b/server/crashmanager/tests/test_signatures_rest.py
@@ -77,7 +77,7 @@ LOG = logging.getLogger("fm.crashmanager.tests.signatures.rest")
 
 
 def _compare_rest_result_to_bucket(
-    result, bucket, size, quality, best_entry=None, latest=None, hist=[], vue=False
+    result, bucket, size, quality, best_entry=None, hist=[], vue=False
 ):
     attributes = {
         "best_entry",
@@ -87,7 +87,6 @@ def _compare_rest_result_to_bucket(
         "frequent",
         "has_optimization",
         "id",
-        "latest_entry",
         "permanent",
         "reassign_in_progress",
         "shortDescription",
@@ -114,7 +113,6 @@ def _compare_rest_result_to_bucket(
     assert result["frequent"] == bucket.frequent
     assert result["has_optimization"] == bool(bucket.optimizedSignature)
     assert result["id"] == bucket.pk
-    assert result["latest_entry"] == latest
     assert result["permanent"] == bucket.permanent
     assert result["reassign_in_progress"] == bucket.reassign_in_progress
     assert result["shortDescription"] == bucket.shortDescription
@@ -302,18 +300,18 @@ def test_rest_signatures_retrieve(api_client, cm, user, ignore_toolfilter):
             assert status_code == requests.codes["ok"], resp["detail"]
             if user.username == "test":
                 if ignore_toolfilter:
-                    size, quality, best, latest = [
-                        (2, 9, crashes[0].id, crashes[1].id),
-                        (2, 2, crashes[2].id, crashes[3].id),
+                    size, quality, best = [
+                        (2, 9, crashes[0].id),
+                        (2, 2, crashes[2].id),
                     ][i]
                 else:
-                    size, quality, best, latest = [
-                        (1, 9, crashes[0].id, crashes[0].id),
-                        (0, None, None, None),
+                    size, quality, best = [
+                        (1, 9, crashes[0].id),
+                        (0, None, None),
                     ][i]
             else:
-                size, quality, best, latest = (1, 9, crashes[0].id, crashes[0].id)
-            _compare_rest_result_to_bucket(resp, bucket, size, quality, best, latest)
+                size, quality, best = (1, 9, crashes[0].id)
+            _compare_rest_result_to_bucket(resp, bucket, size, quality, best)
 
 
 @pytest.mark.parametrize("user", ["normal"], indirect=True)

--- a/server/frontend/src/components/Signatures/View.vue
+++ b/server/frontend/src/components/Signatures/View.vue
@@ -73,11 +73,7 @@
               />
               <form ref="sigWatchForm" :action="sigWatchUrl" method="post">
                 <input type="hidden" name="bucket" :value="bucket.id" />
-                <input
-                  type="hidden"
-                  name="crash"
-                  :value="bucket.latest_entry"
-                />
+                <input type="hidden" name="crash" :value="latestEntry" />
                 <input
                   type="submit"
                   name="submit"
@@ -161,6 +157,10 @@ export default defineComponent({
     },
     editUrl: {
       type: String,
+      required: true,
+    },
+    latestEntry: {
+      type: Number,
       required: true,
     },
     optUrl: {


### PR DESCRIPTION
This doesn't need to be in toolfilter or in the bucket, since it is only used as a minimum value for the watch on incoming crashes.

Fixes #1049 