### PR TITLE
Use Vue for bugzilla template editor

### DIFF
--- a/server/crashmanager/forms.py
+++ b/server/crashmanager/forms.py
@@ -1,7 +1,7 @@
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Div, Field, Layout, Submit
 from django.conf import settings
-from django.forms import CharField, EmailField, ModelForm, Textarea, TextInput
+from django.forms import EmailField, ModelForm, Textarea, TextInput
 from rest_framework.exceptions import ValidationError
 
 from .models import BugzillaTemplate, User

--- a/server/crashmanager/forms.py
+++ b/server/crashmanager/forms.py
@@ -12,67 +12,6 @@ class Row(Div):
 
 
 class BugzillaTemplateBugForm(ModelForm):
-    helper = FormHelper()
-    helper.layout = Layout(
-        HTML("""<div v-pre>"""),
-        Row(Field("name", wrapper_class="col-md-6")),
-        "summary",
-        Row(
-            Field("product", wrapper_class="col-md-6"),
-            Field("component", wrapper_class="col-md-6"),
-        ),
-        HTML("""</div>"""),
-        HTML("""<ppcselect></ppcselect>"""),
-        HTML("""<div v-pre>"""),
-        Row(
-            Field("whiteboard", wrapper_class="col-md-6"),
-            Field("keywords", wrapper_class="col-md-6"),
-        ),
-        Row(
-            Field("op_sys", wrapper_class="col-md-6"),
-            Field("platform", wrapper_class="col-md-6"),
-        ),
-        Row(
-            Field("cc", wrapper_class="col-md-6"),
-            Field("assigned_to", wrapper_class="col-md-6"),
-        ),
-        Row(
-            Field("priority", wrapper_class="col-md-6"),
-            Field("severity", wrapper_class="col-md-6"),
-        ),
-        Row(
-            Field("alias", wrapper_class="col-md-6"),
-            Field("qa_contact", wrapper_class="col-md-6"),
-        ),
-        Row(
-            Field("version", wrapper_class="col-md-6"),
-            Field("target_milestone", wrapper_class="col-md-6"),
-        ),
-        Row(
-            Field("blocks", wrapper_class="col-md-6"),
-            Field("dependson", wrapper_class="col-md-6"),
-        ),
-        "attrs",
-        "description",
-        "security",
-        Row(Field("security_group", wrapper_class="col-md-6")),
-        Row(Field("testcase_filename", wrapper_class="col-md-6")),
-        Submit("submit", "Save", css_class="btn btn-danger"),
-        HTML(
-            """<a href="{% url 'crashmanager:templates' %}" class="btn btn-default">"""
-            """Cancel</a>"""
-        ),
-        HTML("""</div>"""),
-    )
-    product = CharField(
-        label="Current product (choose below)",
-        widget=TextInput(attrs={"disabled": True}),
-    )
-    component = CharField(
-        label="Current component (choose below)",
-        widget=TextInput(attrs={"disabled": True}),
-    )
-
     class Meta:
         model = BugzillaTemplate
         fields = [
@@ -124,13 +63,6 @@ class BugzillaTemplateBugForm(ModelForm):
             "blocks": "Blocks",
             "dependson": "Depends On",
         }
-
-        widgets = {}
-        for field in fields:
-            if field not in ["description", "attrs", "security"]:
-                widgets[field] = TextInput()
-
-        widgets["attrs"] = Textarea(attrs={"rows": 2})
 
 
 class BugzillaTemplateCommentForm(ModelForm):

--- a/server/crashmanager/templates/bugzilla/create_edit.html
+++ b/server/crashmanager/templates/bugzilla/create_edit.html
@@ -7,10 +7,18 @@
 <div class="panel panel-info">
     <div class="panel-heading"><i class="bi bi-card-list"></i> {{ title }}</div>
     <div class="panel-body">
-        <form method="post">
-            {% csrf_token %}
-            {% crispy form %}
-        </form>
+        {% if mode == "Comment" %}
+            <form method="post">
+                {% csrf_token %}
+                {% crispy form %}
+            </form>
+        {% else %}
+            <bugpublicationform
+                :provider-id="{{ provider.pk }}"
+                :template-id="{{ template_id }}"
+                :is-bug-template-creation="true"
+            />
+        {% endif %}
     </div>
 </div>
 {% endblock body_content %}

--- a/server/crashmanager/tests/test_bugs.py
+++ b/server/crashmanager/tests/test_bugs.py
@@ -84,18 +84,23 @@ def test_bug_providers_simple_get(client, cm, name, kwargs):
     ("name", "kwargs"),
     [
         ("crashmanager:templates", {}),
-        ("crashmanager:templatecreatebug", {}),
+        ("crashmanager:templatecreatebug", {"provider": 0}),
         ("crashmanager:templatecreatecomment", {}),
-        ("crashmanager:templateedit", {"templateId": 0}),
+        ("crashmanager:templateedit", {"templateId": 0, "provider": 0}),
         ("crashmanager:templatedel", {"templateId": 0}),
     ],
 )
 def test_bugzilla_templates_simple_get(client, cm, name, kwargs):
     """No errors are thrown in template"""
+
+    query_params = {}
+    if "provider" in kwargs:
+        kwargs.pop("provider")
+        query_params["provider"] = cm.create_bugprovider().pk
     client.login(username="test", password="test")
     if "templateId" in kwargs:
         kwargs["templateId"] = cm.create_template().pk
-    response = client.get(reverse(name, kwargs=kwargs))
+    response = client.get(reverse(name, kwargs=kwargs), query_params=query_params)
     LOG.debug(response)
     assert response.status_code == requests.codes["ok"]
 

--- a/server/crashmanager/views.py
+++ b/server/crashmanager/views.py
@@ -1616,7 +1616,17 @@ class BugzillaTemplateEditView(UpdateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+
+        if "provider" in self.request.GET:
+            provider = get_object_or_404(BugProvider, pk=self.request.GET["provider"])
+        else:
+            user = User.get_or_create_restricted(self.request.user)[0]
+            provider = get_object_or_404(BugProvider, pk=user.defaultProviderId)
+
         context["title"] = "Edit template"
+        context["template_id"] = self.kwargs[self.pk_url_kwarg]
+        context["provider"] = provider
+        context["mode"] = "Bug" if self.object.mode == BugzillaTemplateMode.Bug else "Comment"
         return context
 
     def get_form_class(self):
@@ -1635,6 +1645,15 @@ class BugzillaTemplateBugCreateView(CreateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["title"] = "Create a bug template"
+
+        if "provider" in self.request.GET:
+            provider = get_object_or_404(BugProvider, pk=self.request.GET["provider"])
+        else:
+            user = User.get_or_create_restricted(self.request.user)[0]
+            provider = get_object_or_404(BugProvider, pk=user.defaultProviderId)
+
+        context["provider"] = provider
+        context["mode"] = "Bug"
         return context
 
     def form_valid(self, form):
@@ -1651,6 +1670,7 @@ class BugzillaTemplateCommentCreateView(CreateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["title"] = "Create a comment template"
+        context["mode"] = "Comment"
         return context
 
     def form_valid(self, form):

--- a/server/crashmanager/views.py
+++ b/server/crashmanager/views.py
@@ -1626,7 +1626,9 @@ class BugzillaTemplateEditView(UpdateView):
         context["title"] = "Edit template"
         context["template_id"] = self.kwargs[self.pk_url_kwarg]
         context["provider"] = provider
-        context["mode"] = "Bug" if self.object.mode == BugzillaTemplateMode.Bug else "Comment"
+        context["mode"] = (
+            "Bug" if self.object.mode == BugzillaTemplateMode.Bug else "Comment"
+        )
         return context
 
     def get_form_class(self):

--- a/server/frontend/src/api.js
+++ b/server/frontend/src/api.js
@@ -47,8 +47,13 @@ export const listCrashes = async (params) =>
 export const listBugProviders = async () =>
   (await mainAxios.get("/crashmanager/rest/bugproviders/")).data;
 
-export const listTemplates = async () =>
-  (await mainAxios.get("/crashmanager/rest/bugzilla/templates/")).data;
+export const listTemplates = async (id) => {
+  const path =
+    id !== -1 && id
+      ? `/crashmanager/rest/bugzilla/templates/${id}/`
+      : "/crashmanager/rest/bugzilla/templates/";
+  return (await mainAxios.get(path)).data;
+};
 
 export const listUnreadNotifications = async (params) =>
   (await mainAxios.get("/crashmanager/rest/inbox/", { params })).data;
@@ -104,3 +109,10 @@ export const reportMetadata = async (params) =>
 export const reportConfiguration = async (params) =>
   (await mainAxios.get("/covmanager/reportconfigurations/api/", { params }))
     .data;
+
+export const createBugzillaBugTemplate = async (data) =>
+  (await mainAxios.post("/crashmanager/bugzilla/templates/create-bug/", data))
+    .data;
+
+export const updateBugzillaBugTemplate = async (id, data) =>
+  (await mainAxios.post(`/crashmanager/bugzilla/templates/${id}/`, data)).data;

--- a/server/frontend/src/components/Bugs/FullPPCSelect.vue
+++ b/server/frontend/src/components/Bugs/FullPPCSelect.vue
@@ -14,6 +14,8 @@
       :template-product="templateProduct"
       :template-component="templateComponent"
       style-class="col-md-4"
+      @update-product="product = $event"
+      @update-component="component = $event"
     />
   </div>
 </template>
@@ -45,11 +47,13 @@ export default defineComponent({
       default: "",
     },
   },
-  setup(props) {
+  setup(props, { emit }) {
     const providers = ref([]);
     const selectedProvider = ref(null);
     const providerHostname = ref("");
     const provider = ref(null);
+    const product = ref("");
+    const component = ref("");
 
     onMounted(async () => {
       const data = await api.listBugProviders();
@@ -71,11 +75,27 @@ export default defineComponent({
       providerHostname.value = provider.value.hostname;
     });
 
+    watch(
+      () => product.value,
+      () => {
+        emit("update-product", product.value);
+      },
+    );
+
+    watch(
+      () => component.value,
+      () => {
+        emit("update-component", component.value);
+      },
+    );
+
     return {
       providers,
       selectedProvider,
       providerHostname,
       provider,
+      product,
+      component,
     };
   },
 });

--- a/server/frontend/src/router.js
+++ b/server/frontend/src/router.js
@@ -8,6 +8,7 @@ import CovManagerSummary from "./components/Covmanager/Summary.vue";
 import CrashesList from "./components/Crashes/List.vue";
 import PoolView from "./components/Pools/View.vue";
 import SignaturesList from "./components/Signatures/List.vue";
+import BugPublicationForm from "./components/Bugs/PublicationForm.vue";
 
 const routes = [
   {
@@ -21,6 +22,12 @@ const routes = [
     path: "/crashmanager/crashes/watch/:sigid/",
     name: "crashes-watch",
     component: CrashesList,
+  },
+  {
+    // Be careful to keep this route up-to-date with the one in server/crashmanager/urls.py
+    path: "/crashmanager/crashes/:id/createbug/",
+    name: "crashes-createbug",
+    component: BugPublicationForm,
   },
   {
     // Be careful to keep this route up-to-date with the one in server/crashmanager/urls.py


### PR DESCRIPTION
Merge https://github.com/MozillaSecurity/FuzzManager-dev/pull/18

This simplifies bugzilla template editing/creation by using the same Vue component as is used to log a bug with the template.

Fixes #992 