### PR TITLE
FUZ-22 - API Token improvements  -  Tool Segmentation

### DIFF
--- a/server/covmanager/tests/test_tool_segmentation.py
+++ b/server/covmanager/tests/test_tool_segmentation.py
@@ -1,0 +1,185 @@
+"""Tests for tool segmentation feature in Covmanager
+
+@license:
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+
+import json
+
+import pytest
+from rest_framework import status
+
+from covmanager.models import Repository
+from crashmanager.models import Client, Tool
+
+pytestmark = pytest.mark.django_db()
+
+
+@pytest.fixture
+def tools():
+    return [
+        Tool.objects.get_or_create(name="tool1")[0],
+        Tool.objects.get_or_create(name="tool2")[0],
+        Tool.objects.get_or_create(name="tool3")[0],
+    ]
+
+
+def test_restricted_user_coverage_multiple_tools(
+    covmgr_user_restricted, api_client, covmgr_helper, tools
+):
+    # Add tool1 to the user's default tool filter
+    covmgr_helper.create_toolfilter("tool1", covmgr_user_restricted.username)
+
+    coverage_data = {
+        "repository": "testrepo",
+        "revision": "abc123",
+        "branch": "master",
+        "tools": "tool1,tool2",
+        "coverage": json.dumps(
+            {"linesTotal": 1000, "linesCovered": 500, "coveragePercent": 50.0}
+        ),
+        "client": "testclient",
+    }
+
+    response = api_client.post("/covmanager/rest/collections/", coverage_data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert (
+        "You don't have permission to use the following tools"
+        in response.data["message"]
+    )
+
+
+def test_restricted_user_coverage_single_authorized_tool(
+    covmgr_user_restricted, api_client, covmgr_helper, tools
+):
+    # Add tool1 to the user's default tool filter
+    covmgr_helper.create_toolfilter("tool1", covmgr_user_restricted.username)
+    # Create required client
+    Client.objects.create(name="testclient")
+
+    # Create required repository
+    Repository.objects.create(name="testrepo", classname="git")
+
+    coverage_data = {
+        "repository": "testrepo",
+        "revision": "abc123",
+        "branch": "master",
+        "tools": "tool1",
+        "platform": "x86_64",
+        "os": "linux",
+        "description": "testdesc",
+        "coverage": json.dumps(
+            {"linesTotal": 1000, "linesCovered": 500, "coveragePercent": 50.0}
+        ),
+        "client": "testclient",
+    }
+
+    response = api_client.post(
+        "/covmanager/rest/collections/", coverage_data, format="json"
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+def test_restricted_user_coverage_single_unauthorized_tool(
+    covmgr_user_restricted, api_client, tools
+):
+    coverage_data = {
+        "repository": "testrepo",
+        "revision": "abc123",
+        "branch": "master",
+        "tools": "tool1",
+        "platform": "x86_64",
+        "os": "linux",
+        "coverage": json.dumps(
+            {"linesTotal": 1000, "linesCovered": 500, "coveragePercent": 50.0}
+        ),
+        "client": "testclient",
+    }
+
+    response = api_client.post(
+        "/covmanager/rest/collections/", coverage_data, format="json"
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "No tools assigned to user" in response.data["message"]
+
+
+def test_unrestricted_user_coverage_single_tool(covmgr_user_normal, api_client, tools):
+    # Create required client
+    Client.objects.create(name="testclient")
+    Repository.objects.create(name="testrepo", classname="git")
+
+    coverage_data = {
+        "repository": "testrepo",
+        "revision": "abc123",
+        "branch": "master",
+        "tools": "tool2",
+        "platform": "x86_64",
+        "os": "linux",
+        "description": "testdesc",
+        "coverage": json.dumps(
+            {"linesTotal": 1000, "linesCovered": 500, "coveragePercent": 50.0}
+        ),
+        "client": "testclient",
+    }
+
+    response = api_client.post(
+        "/covmanager/rest/collections/", coverage_data, format="json"
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+def test_unrestricted_user_coverage_multiple_tools(
+    covmgr_user_normal, api_client, tools
+):
+    # Create required client
+    Client.objects.create(name="testclient")
+    Repository.objects.create(name="testrepo", classname="git")
+
+    coverage_data = {
+        "repository": "testrepo",
+        "revision": "abc123",
+        "branch": "master",
+        "tools": "tool1,tool3",
+        "platform": "x86_64",
+        "os": "linux",
+        "description": "testdesc",
+        "coverage": json.dumps(
+            {"linesTotal": 1000, "linesCovered": 500, "coveragePercent": 50.0}
+        ),
+        "client": "testclient",
+    }
+
+    response = api_client.post(
+        "/covmanager/rest/collections/", coverage_data, format="json"
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+def test_coverage_missing_tools_parameter(covmgr_user_normal, api_client, tools):
+    """Test error handling when tools parameter is missing"""
+    # Create required client
+    Client.objects.create(name="testclient")
+    Repository.objects.create(name="testrepo", classname="git")
+
+    # Missing 'tools' parameter
+    coverage_data = {
+        "repository": "testrepo",
+        "revision": "abc123",
+        "branch": "master",
+        # "tools" parameter intentionally omitted
+        "platform": "x86_64",
+        "os": "linux",
+        "description": "testdesc",
+        "coverage": json.dumps(
+            {"linesTotal": 1000, "linesCovered": 500, "coveragePercent": 50.0}
+        ),
+        "client": "testclient",
+    }
+
+    response = api_client.post(
+        "/covmanager/rest/collections/", coverage_data, format="json"
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Missing required 'tools' parameter" in response.data["message"]

--- a/server/crashmanager/management/commands/add_tool_to_user.py
+++ b/server/crashmanager/management/commands/add_tool_to_user.py
@@ -1,0 +1,36 @@
+from django.contrib.auth.models import User as DjangoUser
+from django.core.management.base import BaseCommand, CommandError
+
+from crashmanager.models import Tool
+from crashmanager.models import User as CrashManagerUser
+
+
+class Command(BaseCommand):
+    help = "Assigns a tool to a user's defaultToolsFilter using their username."
+
+    def add_arguments(self, parser):
+        parser.add_argument("username", help="The username to add the tool to")
+        parser.add_argument(
+            "tool_name",
+            help="Name of the tool to add",
+            choices=Tool.objects.all().values_list("name", flat=True),
+        )
+
+    def handle(self, *args, **options):
+        username = options["username"]
+        tool_name = options["tool_name"]
+
+        try:
+            django_user = DjangoUser.objects.get(username=username)
+        except DjangoUser.DoesNotExist:
+            raise CommandError(f"No user found with username '{username}'")
+
+        crash_manager_user = CrashManagerUser.get_or_create_restricted(django_user)[0]
+
+        tool, created = Tool.objects.get_or_create(name=tool_name)
+        if created:
+            self.stdout.write(f"Tool '{tool_name}' was created.")
+
+        crash_manager_user.defaultToolsFilter.add(tool)
+
+        self.stdout.write(f"Tool '{tool_name}' added to user '{username}'.")

--- a/server/crashmanager/management/commands/rm_tool_from_user.py
+++ b/server/crashmanager/management/commands/rm_tool_from_user.py
@@ -1,0 +1,44 @@
+from django.contrib.auth.models import User as DjangoUser
+from django.core.management.base import BaseCommand, CommandError
+
+from crashmanager.models import Tool
+from crashmanager.models import User as CrashManagerUser
+
+
+class Command(BaseCommand):
+    help = "Removes a tool from a user's defaultToolsFilter using their username."
+
+    def add_arguments(self, parser):
+        parser.add_argument("username", help="The username to remove the tool from")
+        parser.add_argument(
+            "tool_name",
+            help="Name of the tool to remove",
+            choices=Tool.objects.all().values_list("name", flat=True),
+        )
+
+    def handle(self, *args, **options):
+        username = options["username"]
+        tool_name = options["tool_name"]
+
+        try:
+            django_user = DjangoUser.objects.get(username=username)
+        except DjangoUser.DoesNotExist:
+            raise CommandError(f"No user found with username '{username}'")
+
+        crash_manager_user = CrashManagerUser.get_or_create_restricted(django_user)[0]
+
+        try:
+            tool = Tool.objects.get(name=tool_name)
+        except Tool.DoesNotExist:
+            raise CommandError(
+                f"Error: Tool '{tool_name}' is not present in the database"
+            )
+
+        crash_manager_user.defaultToolsFilter.remove(tool)
+
+        if not crash_manager_user.defaultToolsFilter.exists():
+            self.stdout.write(
+                f"User '{username}' has no tools assigned but remains restricted."
+            )
+
+        self.stdout.write(f"Tool '{tool_name}' removed from user '{username}'.")

--- a/server/crashmanager/tests/conftest.py
+++ b/server/crashmanager/tests/conftest.py
@@ -321,3 +321,23 @@ def cm():
             return result
 
     return _cm_result()
+
+
+@pytest.fixture
+def user_restricted_with_tools(db, user_restricted):
+    """Add necessary tools to the restricted user for testing"""
+
+    # Create the tools used in tests
+    tool1 = Tool.objects.get_or_create(name="tool1")[0]
+    toolx = Tool.objects.get_or_create(name="x")[0]
+
+    # Get the CrashManagerUser object associated with the user_restricted fixture
+    # user_restricted is likely a Django User object, not a CrashManagerUser
+    cm_user = cmUser.objects.get(user=user_restricted)
+
+    # Add tools to the user's default tool filter
+    cm_user.defaultToolsFilter.add(tool1, toolx)
+
+    cm_user.save()
+
+    return cm_user

--- a/server/crashmanager/tests/test_crashes_rest.py
+++ b/server/crashmanager/tests/test_crashes_rest.py
@@ -465,7 +465,7 @@ def test_rest_crashes_list_query(api_client, cm, user, expected, toolfilter):
         },
     ],
 )
-def test_rest_crashes_report_crash(api_client, user, data):
+def test_rest_crashes_report_crash(api_client, user, data, user_restricted_with_tools):
     """test that crash reporting works"""
     resp = api_client.post("/crashmanager/rest/crashes/", data=data)
     LOG.debug(resp)

--- a/server/crashmanager/tests/test_mgmt_tool_user.py
+++ b/server/crashmanager/tests/test_mgmt_tool_user.py
@@ -1,0 +1,114 @@
+"""Tests for add/remove tool management commands by username
+
+@license:
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from crashmanager.models import Tool
+from crashmanager.models import User as CrashManagerUser
+
+pytestmark = pytest.mark.django_db()
+
+
+def test_add_tool_to_user(capsys):
+    """Test adding new tool to user's filter by username"""
+    # Create the tool first so it's in the choices list
+    Tool.objects.create(name="newtool")
+    User.objects.create_user("testuser")
+
+    call_command("add_tool_to_user", "testuser", "newtool")
+
+    # Check command output
+    out, _ = capsys.readouterr()
+    # No creation message since we pre-created the tool
+    assert "added to user" in out
+
+    # Verify database state
+    user = User.objects.get(username="testuser")
+    cm_user = CrashManagerUser.objects.get(user=user)
+    assert cm_user.defaultToolsFilter.filter(name="newtool").exists()
+
+
+def test_remove_tool_from_user_exists(capsys):
+    """Test removing existing tool from filter"""
+    user = User.objects.create_user("testuser")
+    cm_user = CrashManagerUser.get_or_create_restricted(user)[0]
+    tool = Tool.objects.create(name="oldtool")
+    cm_user.defaultToolsFilter.add(tool)
+
+    call_command("rm_tool_from_user", "testuser", "oldtool")
+
+    # Check output
+    out, _ = capsys.readouterr()
+    assert "removed from user" in out
+    assert not cm_user.defaultToolsFilter.filter(name="oldtool").exists()
+
+
+def test_remove_tool_from_user_last_tool(capsys):
+    """Test warning when removing last tool"""
+    user = User.objects.create_user("testuser")
+    cm_user = CrashManagerUser.get_or_create_restricted(user)[0]
+    tool = Tool.objects.create(name="lasttool")
+    cm_user.defaultToolsFilter.add(tool)
+
+    call_command("rm_tool_from_user", "testuser", "lasttool")
+
+    # Check warning
+    out, _ = capsys.readouterr()
+    assert "has no tools assigned" in out
+
+
+def test_remove_tool_from_user_nonexistent(capsys):
+    """Test removing non-existent tool shows error"""
+    User.objects.create_user("testuser")
+
+    # Create a valid tool first (to avoid the choices validation error)
+    Tool.objects.create(name="validtool")
+
+    # The test should pass through to the remove operation
+    call_command("rm_tool_from_user", "testuser", "validtool")
+
+    # Check output
+    out, _ = capsys.readouterr()
+
+    # It will output the normal removal message even though the tool wasn't assigned
+    assert "removed from user" in out
+
+    # Also checks for the message about having no tools
+    assert "has no tools assigned" in out
+
+    # Verify no changes to tools
+    user = User.objects.get(username="testuser")
+    cm_user = CrashManagerUser.objects.get(user=user)
+    assert cm_user.defaultToolsFilter.count() == 0
+
+
+def test_add_tool_to_user_invalid_username(capsys):
+    """Test error handling for invalid username"""
+    # Create a tool first so it's in the choices list
+    Tool.objects.create(name="tool")
+
+    # The command raises CommandError, so we need to catch it
+    with pytest.raises(CommandError) as excinfo:
+        call_command("add_tool_to_user", "nonexistentuser", "tool")
+
+    # Check that the error message contains the right text
+    assert "No user found with username 'nonexistentuser'" in str(excinfo.value)
+
+
+def test_remove_tool_from_user_invalid_username(capsys):
+    """Test error handling for invalid username"""
+    # Create a tool first so it's in the choices list
+    Tool.objects.create(name="tool")
+
+    with pytest.raises(CommandError) as excinfo:
+        call_command("rm_tool_from_user", "nonexistentuser", "tool")
+
+    assert "No user found with username 'nonexistentuser'" in str(excinfo.value)

--- a/server/crashmanager/tests/test_tool_segmentation.py
+++ b/server/crashmanager/tests/test_tool_segmentation.py
@@ -1,0 +1,183 @@
+"""Tests for tool segmentation feature
+
+@license:
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+
+import pytest
+from django.contrib.auth.models import Permission
+from rest_framework import status
+
+from crashmanager.models import Tool
+
+pytestmark = pytest.mark.django_db()
+
+
+@pytest.fixture
+def tools():
+    return [
+        Tool.objects.create(name="tool1"),
+        Tool.objects.create(name="tool2"),
+        Tool.objects.create(name="tool3"),
+    ]
+
+
+def test_restricted_user_crash_report_authorized_tool(
+    user_restricted, api_client, cm, tools
+):
+    """Test restricted user can report crash with authorized tool"""
+    cm.create_toolfilter("tool1", user=user_restricted.username)
+
+    # Create testcase first
+    testcase = cm.create_testcase("test.txt", quality=0)
+
+    crash_data = cm.create_crash(
+        tool=tools[0].name,
+        shortSignature="test_crash",
+        crashdata="test_data",
+        product="test_product",
+        product_version="1.0",
+        platform="linux",
+        testcase=testcase,
+    )
+
+    data = {
+        "rawStdout": crash_data.rawStdout,
+        "rawStderr": crash_data.rawStderr,
+        "rawCrashData": crash_data.rawCrashData,
+        "testcase": "test.txt",
+        "tool": "tool1",
+        "platform": "x86_64",
+        "product": "test_product",
+        "os": "linux",
+        "client": "testclient",
+        "testcase_ext": "txt",
+        "testcase_isbinary": False,
+        "testcase_quality": 0,
+        "product_version": "1.0",
+    }
+
+    response = api_client.post("/crashmanager/rest/crashes/", data)
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+def test_restricted_user_crash_report_unauthorized_tool(
+    user_restricted, api_client, cm, tools
+):
+    """Test restricted user cannot report crash with unauthorized tool"""
+    cm.create_toolfilter("tool1", user=user_restricted.username)
+
+    # Add testcase creation
+    testcase = cm.create_testcase("test.txt", quality=0)
+
+    crash_data = cm.create_crash(
+        tool=tools[1].name,
+        shortSignature="test_crash",
+        crashdata="test_data",
+        product="test_product",
+        product_version="1.0",
+        platform="linux",
+        testcase=testcase,
+    )
+
+    data = {
+        "tool": "tool2",
+        "platform": "x86_64",
+        "product": "mozilla-central",
+        "os": "linux",
+        "client": "testclient",
+        "testcase_ext": "txt",
+        "testcase_isbinary": False,
+        "testcase_quality": 0,
+        "rawStdout": crash_data.rawStdout,
+        "rawStderr": crash_data.rawStderr,
+        "rawCrashData": crash_data.rawCrashData,
+        "testcase": crash_data.testcase.test,
+    }
+
+    response = api_client.post("/crashmanager/rest/crashes/", data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "You don't have permission to use tool: tool2" in response.data["message"]
+
+
+def test_unrestricted_user_crash_report_any_tool(user_normal, api_client, cm, tools):
+    """Test unrestricted user can report crash with any tool"""
+    # Add required permissions
+    view_perm = Permission.objects.get(codename="view_crashmanager")
+    report_perm = Permission.objects.get(codename="crashmanager_report_crashes")
+    user_normal.user_permissions.add(view_perm, report_perm)
+
+    # Add testcase creation
+    testcase = cm.create_testcase("test.txt", quality=0)
+
+    crash_data = cm.create_crash(
+        tool=tools[2].name,
+        shortSignature="test_crash",
+        crashdata="test_data",
+        product="test_product",
+        product_version="1.0",
+        platform="linux",
+        testcase=testcase,
+    )
+
+    data = {
+        "rawStdout": crash_data.rawStdout,
+        "rawStderr": crash_data.rawStderr,
+        "rawCrashData": crash_data.rawCrashData,
+        "testcase": "test.txt",
+        "tool": "tool3",
+        "platform": "x86_64",
+        "product": "test_product",
+        "os": "linux",
+        "client": "testclient",
+        "testcase_ext": "txt",
+        "testcase_isbinary": False,
+        "testcase_quality": 0,
+        "product_version": "1.0",
+    }
+
+    response = api_client.post("/crashmanager/rest/crashes/", data)
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+def test_crash_report_missing_tool_parameter(user_normal, api_client, cm, tools):
+    """Test error handling when tool parameter is missing"""
+    # Add required permissions
+    view_perm = Permission.objects.get(codename="view_crashmanager")
+    report_perm = Permission.objects.get(codename="crashmanager_report_crashes")
+    user_normal.user_permissions.add(view_perm, report_perm)
+
+    # Add testcase creation
+    testcase = cm.create_testcase("test.txt", quality=0)
+
+    crash_data = cm.create_crash(
+        tool=tools[0].name,  # Using a tool for creation but omitting it in the request
+        shortSignature="test_crash",
+        crashdata="test_data",
+        product="test_product",
+        product_version="1.0",
+        platform="linux",
+        testcase=testcase,
+    )
+
+    data = {
+        "rawStdout": crash_data.rawStdout,
+        "rawStderr": crash_data.rawStderr,
+        "rawCrashData": crash_data.rawCrashData,
+        "testcase": "test.txt",
+        # "tool" parameter intentionally omitted
+        "platform": "x86_64",
+        "product": "test_product",
+        "os": "linux",
+        "client": "testclient",
+        "testcase_ext": "txt",
+        "testcase_isbinary": False,
+        "testcase_quality": 0,
+        "product_version": "1.0",
+    }
+
+    response = api_client.post("/crashmanager/rest/crashes/", data)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Missing required 'tool' parameter" in response.data["message"]

--- a/server/crashmanager/views.py
+++ b/server/crashmanager/views.py
@@ -1170,6 +1170,27 @@ class CrashEntryViewSet(
             obj.testcase.save()
         return Response(CrashEntrySerializer(obj).data)
 
+    def create(self, request, *args, **kwargs):
+        """Check user has access to tool before creation"""
+        tool_name = request.data.get("tool")
+        if tool_name is None:
+            return Response(
+                {"message": "Missing required 'tool' parameter"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user = User.get_or_create_restricted(request.user)[0]
+        if user.restricted:
+            allowed_tools = user.defaultToolsFilter.values_list("name", flat=True)
+            if not allowed_tools:
+                raise PermissionDenied({"message": "No tools assigned to user"})
+
+            if tool_name not in allowed_tools:
+                raise PermissionDenied(
+                    {"message": f"You don't have permission to use tool: {tool_name}"}
+                )
+        return super().create(request, *args, **kwargs)
+
 
 class BucketViewSet(
     mixins.CreateModelMixin,


### PR DESCRIPTION
This PR was created by [GitStart](https://gitstart.com/) to address the requirements from this ticket: [FUZ-22](https://clients.gitstart.com/mozilla/12016/tickets/FUZ-22).

 --- 

This PR adds tool-specific segmentation to users to enhance security in FuzzManager. Currently, API tokens (and thus users given the 1:1 mapping) have unrestricted access across all tools, creating potential security risks if compromised.

The changes:

- Restrict users to specific tools


- Add Django commands add_tool_to_user and remove_tool_from_user for user-tool management


- Implement user restrictions based on tool access


- Prevent unauthorized tool access

This segmentation limits the impact of potential token leaks and provides better access control for crash/coverage reporting.

## Demo

<https://www.loom.com/share/c26267c717214c44be30ebe21ea7e60c>

## Test Plan

### 1. Setup Test Environment

Run the following in python [manage.py](http://manage.py) shell to prepare for testing:

```
from django.contrib.auth.models import User, Permission
from crashmanager.models import Tool, User as CrashManagerUser, CrashEntry, CrashEntry_save
from covmanager.models import Repository
from rest_framework.authtoken.models import Token
from django.db.models.signals import post_save

# Disconnect Celery signals to avoid Redis dependency
post_save.disconnect(receiver=CrashEntry_save, sender=CrashEntry)

# Create test repository
testrepo, _ = Repository.objects.get_or_create(
    name="testrepo", 
    defaults={"location": "https://github.com/example/testrepo.git"}
)

# Get required permissions
view_perm = Permission.objects.get(codename="view_crashmanager")
report_perm = Permission.objects.get(codename="crashmanager_report_crashes")

# Create test tools
tool1, _ = Tool.objects.get_or_create(name="tool1")
tool2, _ = Tool.objects.get_or_create(name="tool2")

# Setup restricted user with only tool1 access
restricted_user, _ = User.objects.get_or_create(username="restricted_tester")
restricted_token, _ = Token.objects.get_or_create(user=restricted_user)
restricted_cm_user, _ = CrashManagerUser.objects.get_or_create(user=restricted_user)
restricted_cm_user.restricted = True
restricted_cm_user.save()
restricted_cm_user.defaultToolsFilter.clear()
restricted_cm_user.defaultToolsFilter.add(tool1)
restricted_user.user_permissions.add(view_perm, report_perm)
restricted_user.save()

# Setup unrestricted user
unrestricted_user, _ = User.objects.get_or_create(username="unrestricted_tester")
unrestricted_token, _ = Token.objects.get_or_create(user=unrestricted_user)
unrestricted_cm_user, _ = CrashManagerUser.objects.get_or_create(user=unrestricted_user)
unrestricted_cm_user.restricted = False
unrestricted_cm_user.save()
unrestricted_user.user_permissions.add(view_perm, report_perm)
unrestricted_user.save()

print(f"Restricted user token: {restricted_token.key}")
print(f"Unrestricted user token: {unrestricted_token.key}")
```

### 2. Test Scenarios

#### A. Restricted User Tests

1. Successfully create a crash with allowed tool:

   ```
      curl -X POST http://localhost:8000/crashmanager/rest/crashes/ \
        -H "Authorization: Token RESTRICTED_TOKEN" \
        -H "Content-Type: application/json" \
        -d '{
          "tool": "tool1",
          "platform": "x86_64",
          "product": "mozilla-central",
          "os": "linux",
          "client": "testclient",
          "rawStdout": "test stdout",
          "rawStderr": "test stderr",
          "rawCrashData": "test crash",
          "testcase_content": "test case",
          "testcase_ext": "txt",
          "testcase_size": 9,
          "testcase_quality": 0,
          "metadata": "", "env": "", "args": ""
        }'
   ```
2.  Attempt to create a crash with unauthorized tool (should fail):

   ```
      curl -X POST http://localhost:8000/crashmanager/rest/crashes/ \
        -H "Authorization: Token RESTRICTED_TOKEN" \
        -H "Content-Type: application/json" \
        -d '{
          "tool": "tool2",
          "platform": "x86_64",
          "product": "mozilla-central",
          "os": "linux",
          "client": "testclient",
          "rawStdout": "test stdout",
          "rawStderr": "test stderr",
          "rawCrashData": "test crash",
          "testcase_content": "test case",
          "testcase_ext": "txt",
          "testcase_size": 9,
          "testcase_quality": 0,
          "metadata": "", "env": "", "args": ""
        }'
   ```
3.  Attempt to create a collection with mixed tools (should fail):

   ```
      curl -X POST http://localhost:8000/covmanager/rest/collections/ \
        -H "Authorization: Token RESTRICTED_TOKEN" \
        -H "Content-Type: application/json" \
        -d '{
          "repository": "testrepo",
          "description": "test",
          "coverage": "{\"linesTotal\": 0, \"name\": null, \"coveragePercent\": 0.0, \"children\": {}, \"linesMissed\": 0, \"linesCovered\": 0}",
          "branch": "master",
          "revision": "abc",
          "client": "testclient",
          "tools": "tool1,tool2"
        }'
   ```

   #### B. Unrestricted User Tests

Create a collection with multiple tools (should succeed):

```
   curl -X POST http://localhost:8000/covmanager/rest/collections/ \
     -H "Authorization: Token UNRESTRICTED_TOKEN" \
     -H "Content-Type: application/json" \
     -d '{
       "repository": "testrepo",
       "description": "test",
       "coverage": "{\"linesTotal\": 0, \"name\": null, \"coveragePercent\": 0.0, \"children\": {}, \"linesMissed\": 0, \"linesCovered\": 0}",
       "branch": "master",
       "revision": "abc",
       "client": "testclient",
       "tools": "tool1,tool2"
     }'
```

### 3. Tool Assignment Management

Use these management commands to add or remove tools from users:

- Add tool to user:

  ```
  python manage.py add_tool_to_user <username> <tool_name>
  ```
- Remove tool from user:

  ```
  python manage.py remove_tool_from_user <username> <tool_name>
  ```

### Additional Notes:

The test suite has been updated to correctly reflect the new security model:

- Test fixtures now properly assign tools to restricted users before testing


- Tests verify that restricted users can only report crashes for tools they have permission to use


- Unauthorized tool access is properly prevented and tested