### PR TITLE
FUZ-19A -  Improve testcase handling in Bugzilla Template

### DIFF
--- a/server/frontend/package-lock.json
+++ b/server/frontend/package-lock.json
@@ -14,6 +14,7 @@
                 "handlebars": "^4.7.8",
                 "js-base64": "^3.7.7",
                 "lodash": "^4.17.21",
+                "mime": "^4.0.6",
                 "prismjs": "^1.29.0",
                 "sweetalert": "^2.1.2",
                 "vue": "^3.4.21",
@@ -8380,12 +8381,18 @@
                 "node": ">=8.6"
             }
         },
-        "node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+        "node_modules/mime": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.6.tgz",
+            "integrity": "sha512-4rGt7rvQHBbaSOF9POGkk1ocRP16Md1x36Xma8sz8h8/vfCUI2OtEIeCqe4Ofes853x4xDoPiFLIT47J5fI/7A==",
+            "funding": [
+                "https://github.com/sponsors/broofa"
+            ],
+            "bin": {
+                "mime": "bin/cli.js"
+            },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=16"
             }
         },
         "node_modules/mime-types": {
@@ -8395,6 +8402,14 @@
             "dependencies": {
                 "mime-db": "1.52.0"
             },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types/node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "engines": {
                 "node": ">= 0.6"
             }

--- a/server/frontend/package.json
+++ b/server/frontend/package.json
@@ -19,6 +19,7 @@
         "handlebars": "^4.7.8",
         "js-base64": "^3.7.7",
         "lodash": "^4.17.21",
+        "mime": "^4.0.6",
         "prismjs": "^1.29.0",
         "sweetalert": "^2.1.2",
         "vue": "^3.4.21",

--- a/server/frontend/src/components/Bugs/TestCaseSection.vue
+++ b/server/frontend/src/components/Bugs/TestCaseSection.vue
@@ -27,6 +27,17 @@
             type="text"
           />
         </div>
+        <div class="col-md-2">
+          <label for="file_extension">File extension:</label>
+
+          <input
+            id="file_extension"
+            type="text"
+            class="form-control"
+            disabled
+            :value="fileExtension"
+          />
+        </div>
       </div>
       <div v-if="!entry.testcase_isbinary" class="row">
         <div class="form-group col-md-12">
@@ -72,20 +83,31 @@ export default defineComponent({
       type: Object,
       required: true,
     },
+    fileExtension: {
+      type: String,
+      required: true,
+    },
+    fileName: {
+      type: String,
+      required: true,
+    },
   },
 
-  emits: ["update-not-attach-test", "update-filename", "update-content"],
-
+  emits: [
+    "update-not-attach-test",
+    "update-filename",
+    "update-content",
+    "update-attachment-extension",
+  ],
   setup(props, { emit }) {
     const notAttachTest = ref(false);
     const filename = ref("");
+    const filenameExtension = ref("");
     const content = ref("Content loading...");
 
     onMounted(async () => {
       notAttachTest.value = props.initialNotAttachTest;
-      filename.value = props.template
-        ? props.template.testcase_filename
-        : props.entry.testcase.split(/[\\/]/).pop();
+      filename.value = props.fileName;
 
       if (!props.entry.testcase_isbinary) {
         content.value = await api.retrieveCrashTestCase(props.entry.id);
@@ -114,6 +136,7 @@ export default defineComponent({
       notAttachTest,
       filename,
       content,
+      filenameExtension,
     };
   },
 });


### PR DESCRIPTION
This PR was created by [GitStart](https://gitstart.com/) to address the requirements from this ticket: [FUZ-19](https://clients.gitstart.com/mozilla/12016/tickets/FUZ-19).

 --- 

**What is in the PR?**

This PR improves how we handle testcase attachments in Bugzilla bug reports. Here's what changed:

1. Made attachment filenames easier to enter:
   - Can now use templates with file extensions from crash testcases
   - Added support for using filename in bug descriptions with `{{testcase_attachment}}`
2. Added automatic mime-type detection:
   - Used 'mime' npm package to detect correct mime-types from file extensions
   - Falls back to:
     - application/octet-stream (for binary files)
     - text/plain (for text files)

**CLIENT DEMO VIDEO: [https://www.loom.com/share/af46fd8c8bc140509f71ff5f76ca7c52?sid=22c7c360-64bb-4f5e-81db-13c29da909f7](https://www.loom.com/share/af46fd8c8bc140509f71ff5f76ca7c52?sid=22c7c360-64bb-4f5e-81db-13c29da909f7)**