### PR TITLE
Taskmanager should look for schedulerId in "status", not in "task"

### DIFF
--- a/server/taskmanager/management/commands/taskmanager_pulse_listen.py
+++ b/server/taskmanager/management/commands/taskmanager_pulse_listen.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
                 msg.delivery_info["exchange"],
                 body["status"]["taskId"],
             )
-            if body["task"]["schedulerId"] == "audit":
+            if body["status"]["schedulerId"] == "audit":
                 LOG.debug(
                     "ignoring task %s update for schedulerId %s",
                     body["status"]["taskId"],


### PR DESCRIPTION
The pulse message differs from the normal API response. We have test fixtures for this data, but mocking the management command is not trivial (TODO).

Regression from #1082 