### PR TITLE
Reporter cleanup

### DIFF
--- a/Collector/Collector.py
+++ b/Collector/Collector.py
@@ -29,12 +29,17 @@ from FTB.ProgramConfiguration import ProgramConfiguration
 from FTB.Running.AutoRunner import AutoRunner
 from FTB.Signatures.CrashInfo import CrashInfo
 from FTB.Signatures.CrashSignature import CrashSignature
-from Reporter.Reporter import Reporter, remote_checks, signature_checks
+from Reporter.Reporter import (
+    InvalidDataError,
+    Reporter,
+    remote_checks,
+    signature_checks,
+)
 
 __all__ = []
 __version__ = 0.1
 __date__ = "2014-10-01"
-__updated__ = "2014-10-01"
+__updated__ = "2025-04-08"
 
 
 class Collector(Reporter):
@@ -70,7 +75,7 @@ class Collector(Reporter):
         """
         with ZipFile(zipFileName, "r") as zipFile:
             if zipFile.testzip():
-                raise RuntimeError(f"Bad CRC for downloaded zipfile {zipFileName}")
+                raise InvalidDataError(f"Bad CRC for downloaded zipfile {zipFileName}")
 
             # Now clean the signature directory, only deleting signatures and metadata
             for sigFile in os.listdir(self.sigCacheDir):
@@ -278,7 +283,9 @@ class Collector(Reporter):
         resp_json = self.get(url).json()
 
         if not isinstance(resp_json, dict):
-            raise RuntimeError(f"Server sent malformed JSON response: {resp_json!r}")
+            raise InvalidDataError(
+                f"Server sent malformed JSON response: {resp_json!r}"
+            )
 
         if not resp_json["testcase"]:
             return None
@@ -286,7 +293,7 @@ class Collector(Reporter):
         response = self.get(dlurl)
 
         if "content-disposition" not in response.headers:
-            raise RuntimeError(f"Server sent malformed response: {response!r}")
+            raise InvalidDataError(f"Server sent malformed response: {response!r}")
 
         local_filename = f"{crashId}{os.path.splitext(resp_json['testcase'])[1]}"
         with open(local_filename, "wb") as output:
@@ -316,7 +323,7 @@ class Collector(Reporter):
             resp_json = self.get(next_url, params=params).json()
 
             if not isinstance(resp_json, dict):
-                raise RuntimeError(
+                raise InvalidDataError(
                     f"Server sent malformed JSON response: {resp_json!r}"
                 )
 
@@ -336,7 +343,9 @@ class Collector(Reporter):
                 response = self.get(url)
 
                 if "content-disposition" not in response.headers:
-                    raise RuntimeError(f"Server sent malformed response: {response!r}")
+                    raise InvalidDataError(
+                        f"Server sent malformed response: {response!r}"
+                    )
 
                 local_filename = "%d%s" % (
                     crash["id"],

--- a/Collector/tests/test_Collector.py
+++ b/Collector/tests/test_Collector.py
@@ -27,6 +27,7 @@ from Collector.Collector import Collector, main
 from crashmanager.models import CrashEntry
 from FTB.ProgramConfiguration import ProgramConfiguration
 from FTB.Signatures.CrashInfo import CrashInfo
+from Reporter.Reporter import InvalidDataError, ServerError
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures"
 
@@ -182,7 +183,7 @@ def test_collector_submit(mock_expanduser, live_server, tmp_path, fm_user):
 
     collector._session.post = lambda *_, **__: response_t()
 
-    with pytest.raises(RuntimeError, match="Server unexpectedly responded"):
+    with pytest.raises(ServerError, match="Server unexpectedly responded"):
         collector.submit(crashInfo, str(testcase_path))
 
 
@@ -248,7 +249,7 @@ def test_collector_refresh(capsys, tmp_path):
 
     collector._session.get = lambda *_, **__: response_t()
 
-    with pytest.raises(RuntimeError, match="Server unexpectedly responded"):
+    with pytest.raises(ServerError, match="Server unexpectedly responded"):
         collector.refresh()
 
     # check that bad zips raise errors
@@ -277,7 +278,7 @@ def test_collector_refresh(capsys, tmp_path):
 
         collector._session.get = lambda *_, **__: response_t()
 
-        with pytest.raises(RuntimeError, match="Bad CRC"):
+        with pytest.raises(InvalidDataError, match="Bad CRC"):
             collector.refresh()
 
 
@@ -378,7 +379,7 @@ def test_collector_download(tmp_path, monkeypatch):
         text = "Not found"
 
     collector._session.get = myget1
-    with pytest.raises(RuntimeError, match="Server unexpectedly responded"):
+    with pytest.raises(ServerError, match="Server unexpectedly responded"):
         collector.download(123)
 
     # download with no testcase
@@ -402,7 +403,7 @@ def test_collector_download(tmp_path, monkeypatch):
             return []
 
     collector._session.get = myget1
-    with pytest.raises(RuntimeError, match="malformed JSON"):
+    with pytest.raises(InvalidDataError, match="malformed JSON"):
         collector.download(123)
 
     # REST query returns http error
@@ -411,5 +412,5 @@ def test_collector_download(tmp_path, monkeypatch):
         text = "Not found"
 
     collector._session.get = myget1
-    with pytest.raises(RuntimeError, match="Server unexpectedly responded"):
+    with pytest.raises(ServerError, match="Server unexpectedly responded"):
         collector.download(123)

--- a/CovReporter/CovReporter.py
+++ b/CovReporter/CovReporter.py
@@ -21,12 +21,12 @@ import os
 import sys
 
 from FTB import CoverageHelper
-from Reporter.Reporter import Reporter, remote_checks
+from Reporter.Reporter import InvalidDataError, Reporter, remote_checks
 
 __all__ = []
 __version__ = 0.1
 __date__ = "2017-07-10"
-__updated__ = "2017-07-10"
+__updated__ = "2025-04-08"
 
 
 class CovReporter(Reporter):
@@ -186,7 +186,7 @@ class CovReporter(Reporter):
                 }
 
         else:
-            raise RuntimeError("Unknown coverage format")
+            raise InvalidDataError("Unknown coverage format")
 
         # Now we need to calculate the coverage summaries (lines total and covered)
         # for each subtree in the tree. We can do this easily by using a recursive
@@ -223,7 +223,7 @@ class CovReporter(Reporter):
             ret["branch"] = coverage["git"]["branch"]
             return ret
         else:
-            raise RuntimeError("Unknown coverage format")
+            raise InvalidDataError("Unknown coverage format")
 
     @staticmethod
     def create_combined_coverage(coverage_files, version=None):

--- a/EC2Reporter/EC2Reporter.py
+++ b/EC2Reporter/EC2Reporter.py
@@ -26,12 +26,12 @@ import requests
 from fasteners import InterProcessLock
 
 from FTB.ConfigurationFiles import ConfigurationFiles  # noqa
-from Reporter.Reporter import Reporter, remote_checks
+from Reporter.Reporter import Reporter, ServerError, remote_checks
 
 __all__ = []
 __version__ = 0.1
 __date__ = "2014-10-01"
-__updated__ = "2014-10-01"
+__updated__ = "2025-04-08"
 
 
 class EC2Reporter(Reporter):
@@ -268,7 +268,7 @@ def main(argv=None):
                             report = f.read()
                         try:
                             reporter.report(report)
-                        except RuntimeError as e:
+                        except ServerError as e:
                             # Ignore errors if the server is temporarily unavailable
                             print(f"Failed to contact server: {e}", file=sys.stderr)
                     finally:

--- a/EC2Reporter/tests/test_EC2Reporter.py
+++ b/EC2Reporter/tests/test_EC2Reporter.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from EC2Reporter.EC2Reporter import EC2Reporter, main
 from ec2spotmanager.models import Instance, InstancePool
 from ec2spotmanager.tests import create_config, create_instance, create_pool
+from Reporter.Reporter import ServerError
 
 pytestmark = pytest.mark.django_db(transaction=True)
 pytest_plugins = "server.tests"
@@ -61,7 +62,7 @@ def test_ec2reporter_report(mock_expanduser, live_server, tmp_path, fm_user):
         clientId="host2",
     )
 
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(ServerError) as exc:
         reporter.report("data")
     assert "Server unexpectedly responded with status code 404:" in str(exc.value)
 
@@ -94,7 +95,7 @@ def test_ec2reporter_xable(mock_expanduser, live_server, tmp_path, fm_user):
     pool = InstancePool.objects.get(pk=pool.pk)  # re-read
     assert pool.isEnabled
 
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(ServerError) as exc:
         reporter.enable(pool.pk)
     assert "Server unexpectedly responded with status code 406:" in str(exc.value)
     pool = InstancePool.objects.get(pk=pool.pk)  # re-read
@@ -104,7 +105,7 @@ def test_ec2reporter_xable(mock_expanduser, live_server, tmp_path, fm_user):
     pool = InstancePool.objects.get(pk=pool.pk)  # re-read
     assert not pool.isEnabled
 
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(ServerError) as exc:
         reporter.disable(pool.pk)
     assert "Server unexpectedly responded with status code 406:" in str(exc.value)
     pool = InstancePool.objects.get(pk=pool.pk)  # re-read
@@ -135,7 +136,7 @@ def test_ec2reporter_cycle(mock_expanduser, live_server, tmp_path, fm_user):
         clientId="host1",
     )
 
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(ServerError) as exc:
         reporter.cycle(pool.pk)
     assert "Server unexpectedly responded with status code 406:" in str(exc.value)
 

--- a/Reporter/Reporter.py
+++ b/Reporter/Reporter.py
@@ -27,23 +27,41 @@ from FTB.ConfigurationFiles import ConfigurationFiles
 LOG = logging.getLogger(__name__)
 
 
+# Inheriting from RuntimeError because of legacy code.
+# All of these exceptions used to be RuntimeError.
+class ReporterException(RuntimeError):
+    """Base class for Reporter exceptions."""
+
+
+class ConfigurationError(ReporterException):
+    """Error type for configuration problems preventing Reporter from functioning."""
+
+
+class ServerError(ReporterException):
+    """Communication errors encountered by Reporter during operation."""
+
+
+class InvalidDataError(ReporterException):
+    """Reporter data validation failures."""
+
+
 def remote_checks(wrapped):
     """Decorator to perform error checks before using remote features"""
 
     @functools.wraps(wrapped)
     def decorator(self, *args, **kwargs):
         if not self.serverHost:
-            raise RuntimeError(
+            raise ConfigurationError(
                 "Must specify serverHost (configuration property: serverhost) to use "
                 "remote features."
             )
         if not self.serverAuthToken:
-            raise RuntimeError(
-                "Must specify serverAuthToken (configuration property: serverauthtoken)"
-                " to use remote features."
+            raise ConfigurationError(
+                "Must specify serverAuthToken (configuration property: "
+                "serverauthtoken) to use remote features."
             )
         if not self.tool:
-            raise RuntimeError(
+            raise ConfigurationError(
                 "Must specify tool (configuration property: tool) to use remote "
                 "features."
             )
@@ -58,7 +76,7 @@ def signature_checks(wrapped):
     @functools.wraps(wrapped)
     def decorator(self, *args, **kwargs):
         if not self.sigCacheDir:
-            raise RuntimeError(
+            raise ConfigurationError(
                 "Must specify sigCacheDir (configuration property: sigdir) to use "
                 "signatures."
             )
@@ -240,7 +258,7 @@ class Reporter(ABC):
 
     @staticmethod
     def serverError(response):
-        return RuntimeError(
-            "Server unexpectedly responded with status code %s: %s"
-            % (response.status_code, response.text)
+        return ServerError(
+            "Server unexpectedly responded with status code "
+            f"{response.status_code}: {response.text}"
         )

--- a/Reporter/Reporter.py
+++ b/Reporter/Reporter.py
@@ -92,7 +92,7 @@ def requests_retry(wrapped):
             if response.status_code != success:
                 # Allow for a total sleep time of up to 2 minutes if it's
                 # likely that the response codes indicate a temporary error
-                retry_codes = [500, 502, 503, 504]
+                retry_codes = [429, 500, 502, 503, 504]
                 if response.status_code in retry_codes and current_timeout <= max_sleep:
                     LOG.warning(
                         "in %s, server returned %s, retrying...",

--- a/TaskStatusReporter/TaskStatusReporter.py
+++ b/TaskStatusReporter/TaskStatusReporter.py
@@ -204,7 +204,8 @@ def main(argv=None):
                     )
                 time.sleep(opts.keep_reporting + random_offset)
         else:
-            report = opts.report_file.read_text()
+            with InterProcessLock(f"{opts.report_file}.lock"):
+                report = opts.report_file.read_text()
     else:
         report = opts.report
 

--- a/TaskStatusReporter/TaskStatusReporter.py
+++ b/TaskStatusReporter/TaskStatusReporter.py
@@ -26,12 +26,12 @@ import requests
 from fasteners import InterProcessLock
 
 from FTB.ConfigurationFiles import ConfigurationFiles  # noqa
-from Reporter.Reporter import Reporter, remote_checks
+from Reporter.Reporter import Reporter, ServerError, remote_checks
 
 __all__ = []
 __version__ = 0.1
-__date__ = "2014-10-01"
-__updated__ = "2014-10-01"
+__date__ = "2020-04-24"
+__updated__ = "2025-04-08"
 
 
 class TaskStatusReporter(Reporter):
@@ -186,7 +186,7 @@ def main(argv=None):
                             report = f.read()
                         try:
                             reporter.report(report)
-                        except RuntimeError as e:
+                        except ServerError as e:
                             # Ignore errors if the server is temporarily unavailable
                             print(f"Failed to contact server: {e}", file=sys.stderr)
                     finally:

--- a/TaskStatusReporter/tests/test_TaskStatusReporter.py
+++ b/TaskStatusReporter/tests/test_TaskStatusReporter.py
@@ -3,6 +3,7 @@ from urllib.parse import urlsplit
 
 import pytest
 
+from Reporter.Reporter import ServerError
 from taskmanager.models import Task
 from taskmanager.tests import create_pool, create_task
 from TaskStatusReporter.TaskStatusReporter import TaskStatusReporter, main
@@ -58,6 +59,6 @@ def test_taskstatusreporter_report(mock_expanduser, live_server, tmp_path, fm_us
         clientId="host2",
     )
 
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(ServerError) as exc:
         reporter.report("data")
     assert "Server unexpectedly responded with status code 404:" in str(exc.value)


### PR DESCRIPTION
- use specific exception types (still inherit from RuntimeError for legacy code)
- add 429 to retry codes
- clean up arg types for TaskStatusReporter