### PR TITLE
Don't require wheel filename to begin with "FuzzManager"

### DIFF
--- a/repack_wheel.sh
+++ b/repack_wheel.sh
@@ -8,8 +8,8 @@ set -e -x
 #
 
 WORK="$(mktemp -d -t fm-twine-repack-XXXXXX)"
-wheel unpack -d "$WORK" dist/FuzzManager-*.whl
-grep -Ev "^(Provides-Extra: .*|Requires-Dist: .* ; extra == '.*')$" "$WORK"/FuzzManager-*/FuzzManager-*.dist-info/METADATA > "$WORK"/METADATA.new
-mv "$WORK"/METADATA.new "$WORK"/FuzzManager-*/FuzzManager-*.dist-info/METADATA
-wheel pack -d dist "$WORK"/FuzzManager-*
+wheel unpack -d "$WORK" dist/*.whl
+grep -Ev "^(Provides-Extra: .*|Requires-Dist: .* ; extra == '.*')$" "$WORK"/*/*.dist-info/METADATA > "$WORK"/METADATA.new
+mv "$WORK"/METADATA.new "$WORK"/*/*.dist-info/METADATA
+wheel pack -d dist "$WORK"/*
 rm -rf "$WORK"


### PR DESCRIPTION
Generated wheel filenames are lowercase now.