### PR TITLE
Update requirement metadata format when repacking wheel

### DIFF
--- a/repack_wheel.sh
+++ b/repack_wheel.sh
@@ -9,7 +9,7 @@ set -e -x
 
 WORK="$(mktemp -d -t fm-twine-repack-XXXXXX)"
 wheel unpack -d "$WORK" dist/*.whl
-grep -Ev "^(Provides-Extra: .*|Requires-Dist: .* ; extra == '.*')$" "$WORK"/*/*.dist-info/METADATA > "$WORK"/METADATA.new
+grep -Ev "^(Provides-Extra: .*|Requires-Dist: .*;.* extra == .*)$" "$WORK"/*/*.dist-info/METADATA > "$WORK"/METADATA.new
 mv "$WORK"/METADATA.new "$WORK"/*/*.dist-info/METADATA
 wheel pack -d dist "$WORK"/*
 rm -rf "$WORK"


### PR DESCRIPTION
The `extra` argument to `Requires-Dist` changed from using `'` to using `"`.

This caused the extras to make it into the wheel requirements, which caused twine to reject it (can't use a `git+` dependency in pypi, which we do for fuzzing-decision).