### PR TITLE
Remove URL requirements from source metadata

### DIFF
--- a/repack.sh
+++ b/repack.sh
@@ -13,3 +13,18 @@ grep -Ev "^(Provides-Extra: .*|Requires-Dist: .*;.* extra == .*)$" "$WORK"/*/*.d
 mv "$WORK"/METADATA.new "$WORK"/*/*.dist-info/METADATA
 wheel pack -d dist "$WORK"/*
 rm -rf "$WORK"
+
+#
+# Remove `@git+` requires from the source
+#
+# PyPI is now rejecting these.
+#
+
+WORK="$(mktemp -d -t fm-twine-repack-XXXXXX)"
+TAR="$(ls dist/*.tar.*)"
+tar -C "$WORK" -xvaf "$TAR"
+sed -Ei 's/^(Requires-Dist:\s*[A-Za-z0-9][A-Za-z0-9._-]*)\s*@\s*([^ ]+)(.*)$/\1\3/' "$WORK"/*/PKG-INFO
+FN="$(ls "$WORK")"
+rm "$TAR"
+tar -C "$WORK" -cvaf "$TAR" "$FN"
+rm -rf "$WORK"

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
     wheel
 commands =
     python -m build
-    bash repack_wheel.sh
+    bash repack.sh
     twine upload --verbose --skip-existing dist/*
 allowlist_externals =
     bash


### PR DESCRIPTION
We use an `@ URL` requirement for fuzzing-decision, but PyPI is now rejecting this from source distributions in addition to wheels.

This regex will replace:

    Requires-Dist: fuzzing-decision @ git+https://... ; extra == "test"

with

    Requires-Dist: fuzzing-decision ; extra == "test"

The @ URL is still in `setup.cfg`.