### PR TITLE
fix: taskmanager should look for schedulerId in "status", not in "task"

### DIFF
--- a/server/taskmanager/management/commands/taskmanager_pulse_listen.py
+++ b/server/taskmanager/management/commands/taskmanager_pulse_listen.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
                 LOG.debug(
                     "ignoring task %s update for schedulerId %s",
                     body["status"]["taskId"],
-                    body["task"]["schedulerId"],
+                    body["status"]["schedulerId"],
                 )
             else:
                 update_task.delay(body)


### PR DESCRIPTION
This was "fixed" incompletely in #1083.