### PR TITLE
feat(crashmanager): Cleanup very old crashes

### DIFF
--- a/server/crashmanager/management/commands/cleanup_old_crashes.py
+++ b/server/crashmanager/management/commands/cleanup_old_crashes.py
@@ -11,25 +11,49 @@ from crashmanager.models import Bucket, Bug, CrashEntry
 LOG = logging.getLogger("fm.crashmanager.cleanup_old_crashes")
 
 
+# Deleting things in buckets is complicated:
+#
+# Attempting to combine a subset (LIMIT) with a delete yields
+#   "Cannot use 'limit' or 'offset' with delete."
+#
+# Using a nested query with pk_in=<filter query> yields
+#   "This version of MySQL doesn't yet support
+#        'LIMIT & IN/ALL/ANY/SOME subquery'"
+
+
+# So the only way we have left is to manually select a given amount of
+# pks and store them in a list to use pk__in with the list and a DELETE
+# query.
+def _bulk_delete_crashes(qs):
+    while qs.count():
+        pks = list(qs.values_list("pk", flat=True)[:500])
+        CrashEntry.objects.filter(pk__in=pks).delete()
+
+
 class Command(BaseCommand):
     help = "Cleanup old crash entries."
 
     def handle(self, *args, **options):
+        cleanup_crashes_incl_buckets = getattr(settings, "CRASH_MAX_LIFETIME", 365 * 2)
         cleanup_crashes_after_days = getattr(settings, "CLEANUP_CRASHES_AFTER_DAYS", 14)
         cleanup_fixed_buckets_after_days = getattr(
             settings, "CLEANUP_FIXED_BUCKETS_AFTER_DAYS", 3
         )
 
+        # start of day
+        sod = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
+
+        # Select all very-old crashes, regardless of whether bucketed
+        expiry_date = sod - timedelta(days=cleanup_crashes_incl_buckets)
+        crashes = CrashEntry.objects.filter(created__lte=expiry_date)
+        size = crashes.count()
+        if size:
+            LOG.info("Removing %d very old crashes", size)
+        _bulk_delete_crashes(crashes)
+
         # Select all buckets that have been closed for x days
-        now = timezone.now()
-        expiryDate = now - timedelta(
-            days=cleanup_fixed_buckets_after_days,
-            hours=now.hour,
-            minutes=now.minute,
-            seconds=now.second,
-            microseconds=now.microsecond,
-        )
-        bugs = Bug.objects.filter(closed__lt=expiryDate)
+        expiry_date = sod - timedelta(days=cleanup_fixed_buckets_after_days)
+        bugs = Bug.objects.filter(closed__lt=expiry_date)
         for bug in bugs:
             # Deleting the bug causes buckets referring to this bug as well as entries
             # referring these buckets to be deleted as well due to cascading delete.
@@ -40,43 +64,16 @@ class Command(BaseCommand):
             # we have a post-delete receiver on CrashEntry that has to be called for
             # every single deleted entry with the full instance. Maybe Django loads
             # a copy of all instances to be deleted into memory for this purpose.
-            crash_count = CrashEntry.objects.filter(bucket__bug=bug).count()
-            if crash_count:
+            crashes = CrashEntry.objects.filter(bucket__bug=bug)
+            size = crashes.count()
+            if size:
                 LOG.info(
-                    "Removing %d CrashEntry objects from buckets assigned to bug %s",
-                    crash_count,
+                    "Removing %d crashes from buckets assigned to bug %s",
+                    size,
                     bug.externalId,
                 )
-            while crash_count > 500:
-                # Deleting things in buckets is complicated:
-                #
-                # Attempting to combine a subset (LIMIT) with a delete yields
-                #   "Cannot use 'limit' or 'offset' with delete."
-                #
-                # Using a nested query with pk_in=<filter query> yields
-                #   "This version of MySQL doesn't yet support
-                #        'LIMIT & IN/ALL/ANY/SOME subquery'"
-
-                # So the only way we have left is to manually select a given amount of
-                # pks and store them in a list to use pk__in with the list and a DELETE
-                # query.
-
-                pks = list(
-                    CrashEntry.objects.filter(bucket__bug=bug).values_list(
-                        "pk", flat=True
-                    )[:500]
-                )
-                CrashEntry.objects.filter(pk__in=pks).delete()
-                crash_count = CrashEntry.objects.filter(bucket__bug=bug).count()
-
+            _bulk_delete_crashes(crashes)
             bug.delete()
-
-        # Select all buckets that are empty and delete them
-        for bucket in Bucket.objects.annotate(size=Count("crashentry")).filter(
-            size=0, bug=None, permanent=False
-        ):
-            LOG.info("Removing empty bucket %d", bucket.id)
-            bucket.delete()
 
         # Select all entries that are older than x days and either not in any bucket
         # or the bucket has no bug associated with it. If the bucket has a bug
@@ -85,28 +82,19 @@ class Command(BaseCommand):
         #
         # Again, for the same reason as mentioned above, we have to delete entries in
         # batches.
-        expiryDate = now - timedelta(
-            days=cleanup_crashes_after_days,
-            hours=now.hour,
-            minutes=now.minute,
-            seconds=now.second,
-            microseconds=now.microsecond,
-        )
-        old_crashes = CrashEntry.objects.filter(
-            created__lt=expiryDate, bucket__bug=None
-        ).count()
-        if old_crashes:
-            LOG.info("Removing %d old, unbucketed crashes", old_crashes)
-        while old_crashes:
-            pks = list(
-                CrashEntry.objects.filter(
-                    created__lt=expiryDate, bucket__bug=None
-                ).values_list("pk", flat=True)[:500]
-            )
-            CrashEntry.objects.filter(pk__in=pks).delete()
-            old_crashes = CrashEntry.objects.filter(
-                created__lt=expiryDate, bucket__bug=None
-            ).count()
+        expiry_date = sod - timedelta(days=cleanup_crashes_after_days)
+        crashes = CrashEntry.objects.filter(created__lt=expiry_date, bucket__bug=None)
+        size = crashes.count()
+        if size:
+            LOG.info("Removing %d old, unbucketed crashes", size)
+        _bulk_delete_crashes(crashes)
+
+        # Select all buckets that are empty and delete them
+        for bucket in Bucket.objects.annotate(size=Count("crashentry")).filter(
+            size=0, permanent=False
+        ):
+            LOG.info("Removing empty bucket %d", bucket.id)
+            bucket.delete()
 
         # Cleanup all bugs that don't belong to any bucket anymore
         orphan_bugs = Bug.objects.filter(bucket__isnull=True)

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -344,6 +344,7 @@ GCE_AUTH_CACHE = "/tmp/.google_libcloud_auth.fuzzmanager-cluster"
 # BUGZILLA_PASSWORD = "secret"
 # CLEANUP_CRASHES_AFTER_DAYS = 14
 # CLEANUP_FIXED_BUCKETS_AFTER_DAYS = 3
+# CRASH_MAX_LIFETIME = 365 * 2
 ALLOW_EMAIL_EDITION = True
 
 # This is the base directory where the tests/ subdirectory will


### PR DESCRIPTION
Clean up crashes whether they are bucketed or not, when they reach a given age.

This also changes the cleanup command to remove empty buckets even if they have a bug associated. We should only keep buckets around that are marked permanent or are actively matching crashes.

Fixes #1132